### PR TITLE
Add an alternative code path to harvest CKAN sources

### DIFF
--- a/src/bin/harvester.rs
+++ b/src/bin/harvester.rs
@@ -89,7 +89,8 @@ async fn harvest(dir: &Dir, client: &Client, source: Source) -> Result<()> {
     let dir = dir.open_dir(&source.name)?;
 
     let res = match source.r#type {
-        Type::CKAN => ckan::harvest(&dir, client, &source).await,
+        Type::Ckan => ckan::harvest(&dir, client, &source).await,
+        Type::CkanSearch => ckan::harvest_search(&dir, client, &source).await,
     };
 
     res.with_context(move || format!("Failed to harvest source {}", source.name))

--- a/src/harvester/ckan.rs
+++ b/src/harvester/ckan.rs
@@ -86,16 +86,16 @@ async fn fetch_dataset(
 }
 
 pub async fn harvest_search(dir: &Dir, client: &Client, source: &Source) -> Result<()> {
-    const ROWS: usize = 100;
+    let rows = source.batch_size.unwrap_or(100);
 
-    let (count, results, errors) = fetch_datasets_search(dir, client, source, 0, ROWS).await?;
+    let (count, results, errors) = fetch_datasets_search(dir, client, source, 0, rows).await?;
     tracing::info!("Harvesting {} datasets", count);
 
-    let requests = (count + ROWS - 1) / ROWS;
-    let start = (1..requests).map(|request| request * ROWS);
+    let requests = (count + rows - 1) / rows;
+    let start = (1..requests).map(|request| request * rows);
 
     let (results, errors) = iter(start)
-        .map(|start| fetch_datasets_search(dir, client, source, start, ROWS))
+        .map(|start| fetch_datasets_search(dir, client, source, start, rows))
         .buffer_unordered(source.concurrency.unwrap_or(1))
         .fold(
             (results, errors),

--- a/src/harvester/ckan.rs
+++ b/src/harvester/ckan.rs
@@ -80,13 +80,103 @@ async fn fetch_dataset(
             .map_or("Malformed response", |err| &err.message)
     );
 
+    write_dataset(dir, source, package_show.result).await?;
+
+    Ok(())
+}
+
+pub async fn harvest_search(dir: &Dir, client: &Client, source: &Source) -> Result<()> {
+    const ROWS: usize = 100;
+
+    let (count, results, errors) = fetch_datasets_search(dir, client, source, 0, ROWS).await?;
+    tracing::info!("Harvesting {} datasets", count);
+
+    let requests = (count + ROWS - 1) / ROWS;
+    let start = (1..requests).map(|request| request * ROWS);
+
+    let (results, errors) = iter(start)
+        .map(|start| fetch_datasets_search(dir, client, source, start, ROWS))
+        .buffer_unordered(source.concurrency.unwrap_or(1))
+        .fold(
+            (results, errors),
+            |(mut results, mut errors), res| async move {
+                match res {
+                    Ok((_count, results1, errors1)) => {
+                        results += results1;
+                        errors += errors1;
+                    }
+                    Err(err) => {
+                        tracing::error!("{:#}", err);
+
+                        errors += 1;
+                    }
+                }
+
+                (results, errors)
+            },
+        )
+        .await;
+
+    if errors != 0 {
+        tracing::error!("Failed to harvest {} out of {} datasets", errors, results);
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument(skip(dir, client))]
+async fn fetch_datasets_search(
+    dir: &Dir,
+    client: &Client,
+    source: &Source,
+    start: usize,
+    rows: usize,
+) -> Result<(usize, usize, usize)> {
+    tracing::debug!("Fetching {} datasets starting at {}", rows, start);
+
+    let url = source.url.join("/api/3/action/package_search")?;
+
+    let package_search = client
+        .get(url)
+        .query(&[("start", start.to_string()), ("rows", rows.to_string())])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<PackageSearch>()
+        .await?;
+
+    ensure!(
+        package_search.success,
+        "Failed to fetch packages: {}",
+        package_search
+            .error
+            .as_ref()
+            .map_or("Malformed response", |err| &err.message)
+    );
+
+    let count = package_search.result.count;
+    let results = package_search.result.results.len();
+    let mut errors = 0;
+
+    for package in package_search.result.results {
+        if let Err(err) = write_dataset(dir, source, package).await {
+            tracing::error!("{:#}", err);
+
+            errors += 1;
+        }
+    }
+
+    Ok((count, results, errors))
+}
+
+async fn write_dataset(dir: &Dir, source: &Source, package: Package) -> Result<()> {
     let dataset = Dataset {
-        title: package_show.result.title,
-        description: package_show.result.notes,
-        source_url: source.url.join(&format!("/dataset/{}", package_id))?,
+        title: package.title,
+        description: package.notes.unwrap_or_default(),
+        source_url: source.url.join(&format!("/dataset/{}", package.id))?,
     };
 
-    let file = dir.create(package_show.result.id.to_string())?;
+    let file = dir.create(package.id.to_string())?;
 
     dataset.write(file).await?;
 
@@ -108,10 +198,23 @@ struct PackageShow {
 }
 
 #[derive(Deserialize)]
+struct PackageSearch {
+    success: bool,
+    error: Option<Error>,
+    result: PackageSearchResult,
+}
+
+#[derive(Deserialize)]
+struct PackageSearchResult {
+    count: usize,
+    results: Vec<Package>,
+}
+
+#[derive(Deserialize)]
 struct Package {
     id: Uuid,
     title: String,
-    notes: String,
+    notes: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -27,6 +27,7 @@ pub struct Source {
     pub r#type: Type,
     pub url: Url,
     pub concurrency: Option<usize>,
+    pub batch_size: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -30,7 +30,8 @@ pub struct Source {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Type {
-    CKAN,
+    Ckan,
+    CkanSearch,
 }


### PR DESCRIPTION
Uses the `package_search` endpoint instead of the `package_list/show` endpoints which is significantly faster, e.g. 3s instead of 21s to harvest 723 datasets with 100 per request and a concurrency of 3.