### PR TITLE
Add with_retry helper function to handle spurious failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
-      - run: cargo clippy -- --deny warnings
+      - run: cargo clippy --all-targets -- --deny warnings
 
   test:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ tower-http = { version = "0.3", features = ["trace"] }
 tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.2", features = ["serde"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["test-util"] }

--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -30,4 +30,3 @@ source_url = "https://gis.uba.de/smartfinder-client/?lang=de#/datasets/iso/{{id}
 name = "wasser-de"
 type = "wasser_de"
 url = "https://www.wasser-de.de/"
-

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -5,13 +5,12 @@ use bincode::{deserialize, serialize};
 use cap_std::fs::File;
 use serde::{Deserialize, Serialize};
 use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
-use url::Url;
 
 #[derive(Deserialize, Serialize)]
 pub struct Dataset {
     pub title: String,
     pub description: String,
-    pub source_url: Url,
+    pub source_url: String,
 }
 
 impl Dataset {

--- a/src/harvester/ckan.rs
+++ b/src/harvester/ckan.rs
@@ -99,9 +99,7 @@ async fn write_dataset(dir: &Dir, source: &Source, package: Package) -> Result<(
     let dataset = Dataset {
         title: package.title,
         description: package.notes.unwrap_or_default(),
-        source_url: source
-            .source_url()
-            .join(&format!("dataset/{}", package.id))?,
+        source_url: source.source_url().replace("{{name}}", &package.name),
     };
 
     let file = dir.create(package.id)?;
@@ -127,6 +125,7 @@ struct PackageSearchResult {
 #[derive(Deserialize)]
 struct Package {
     id: String,
+    name: String,
     title: String,
     notes: Option<String>,
 }

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -104,7 +104,10 @@ async fn write_dataset(dir: &Dir, source: &Source, record: SummaryRecord) -> Res
     let dataset = Dataset {
         title: record.title,
         description: record.r#abstract,
-        source_url: source.source_url().join(&record.identifier)?,
+        source_url: source
+            .source_url()
+            .replace("{{id}}", &record.identifier)
+            .parse()?,
     };
 
     let file = dir.create(record.identifier)?;

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -29,7 +29,7 @@ pub struct Source {
     pub name: String,
     pub r#type: Type,
     url: Url,
-    source_url: Option<Url>,
+    source_url: Option<String>,
     #[serde(default = "default_concurrency")]
     concurrency: usize,
     #[serde(default = "default_batch_size")]
@@ -45,8 +45,10 @@ fn default_batch_size() -> usize {
 }
 
 impl Source {
-    fn source_url(&self) -> &Url {
-        self.source_url.as_ref().unwrap_or(&self.url)
+    pub fn source_url(&self) -> &str {
+        self.source_url
+            .as_deref()
+            .unwrap_or_else(|| self.url.as_str())
     }
 }
 
@@ -57,6 +59,7 @@ impl fmt::Debug for Source {
             .field("type", &self.r#type)
             // The default format of `Url` is too verbose for the logs.
             .field("url", &self.url.as_str())
+            .field("source_url", &self.source_url)
             .field("concurrency", &self.concurrency)
             .field("batch_size", &self.batch_size)
             .finish()


### PR DESCRIPTION
This employs an exponential back-off strategy without any parameters for now and is intended to be used by the harvester to handle network errors and internal server errors.

Closes #9 