### PR TITLE
Use Rayon to load datasets for indexing using multiple threads.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "cap-std",
  "futures-util",
  "quick-xml",
+ "rayon",
  "reqwest",
  "serde",
  "tantivy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3"
 cap-std = "0.25"
 futures-util = { version = "0.3", default-features = false }
 quick-xml = { version = "0.23", features = ["serialize"] }
+rayon = "1.5"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 tantivy = "0.18"


### PR DESCRIPTION
Let's do this after all as this reduces the time window in which the index does not consistently capture the datasets which might lead to broken links from the search results into the datasets.

Performance does improve measurably:

| strategy | caches | wall time | CPU utilization |
| - | - | - | - |
| serial | cold | 5min | 20% |
| serial | hot | 10s | 250% |
| parallel | cold | 1min | 100% |
| parallel | hot | 5s | 350% |

This is on a CODE-DE VM with 4 cores and 380k datasets. Caches were dropped via `echo 3 > /proc/sys/vm/drop_caches`.