### PR TITLE
Use LZ4 to compress datasets as it is already part of the dependency closure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "bincode",
  "cap-std",
  "futures-util",
+ "lz4_flex",
  "quick-xml",
  "rayon",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ axum = { version = "0.5", default-features = false, features = ["http1", "query"
 bincode = "1.3"
 cap-std = "0.25"
 futures-util = { version = "0.3", default-features = false }
+lz4_flex = { version = "0.9", default-features = false, features = ["std"] }
 quick-xml = { version = "0.23", features = ["serialize"] }
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json"] }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use anyhow::Result;
 use bincode::{deserialize, serialize};
 use cap_std::fs::File;
+use lz4_flex::{compress_prepend_size, decompress_size_prepended};
 use serde::{Deserialize, Serialize};
 use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 use url::Url;
@@ -18,15 +19,17 @@ impl Dataset {
     pub fn read(mut file: File) -> Result<Self> {
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let val = deserialize(&buf)?;
+
+        let val = deserialize(&decompress_size_prepended(&buf)?)?;
 
         Ok(val)
     }
 
     pub async fn write(&self, file: File) -> Result<()> {
-        let mut file = AsyncFile::from_std(file.into_std());
+        let buf = compress_prepend_size(&serialize(self)?);
 
-        file.write_all(&serialize(self)?).await?;
+        let mut file = AsyncFile::from_std(file.into_std());
+        file.write_all(&buf).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Still marked as a draft as we need an expanded dataset definition to be able to measure whether this is worthwhile.

Fixes #3 