### PR TITLE
Parse the DCAP-AP.de license vocabulary to generate a build representation of common licenses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1792,7 @@ dependencies = [
  "quick-xml",
  "rayon",
  "reqwest",
+ "roxmltree",
  "serde",
  "tantivy",
  "tokio",
@@ -2098,3 +2108,9 @@ dependencies = [
  "io-lifetimes",
  "windows-sys",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd94351ac44e70e56b59883e15029a5135f902a8a3020f9c18d580a420e526aa"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1433,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
@@ -1789,6 +1837,7 @@ dependencies = [
  "bincode",
  "cap-std",
  "futures-util",
+ "phf",
  "quick-xml",
  "rayon",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ axum = { version = "0.5", default-features = false, features = ["http1", "query"
 bincode = "1.3"
 cap-std = "0.25"
 futures-util = { version = "0.3", default-features = false }
+phf = { version = "0.11", features = ["macros"] }
 quick-xml = { version = "0.23", features = ["serialize"] }
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,13 @@ tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.2", features = ["serde"] }
 
+[build-dependencies]
+anyhow = "1.0"
+askama = { version = "0.11", default-features = false }
+roxmltree = "0.14"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["test-util"] }
+
 [profile.release]
 lto = "thin"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,76 @@
+use std::env::var_os;
+use std::fs::{read_to_string, write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use askama::Template;
+use roxmltree::Document;
+
+fn main() -> Result<()> {
+    let out_dir = PathBuf::from(var_os("OUT_DIR").unwrap());
+
+    generate_licenses(&out_dir)?;
+
+    Ok(())
+}
+
+fn generate_licenses(out_dir: &Path) -> Result<()> {
+    #[derive(Default)]
+    struct License {
+        identifier: String,
+        label: String,
+    }
+
+    let mut licenses = Vec::new();
+
+    let vocab = read_to_string("vocabulary/licenses.rdf")?;
+
+    let vocab = Document::parse(&vocab)?;
+
+    for node in vocab.root_element().children() {
+        if node.has_tag_name("Concept") {
+            let mut license = License::default();
+
+            for node in node.children() {
+                if node.has_tag_name("identifier") {
+                    license.identifier = node
+                        .text()
+                        .ok_or_else(|| anyhow!("Missing identifier text"))?
+                        .to_owned();
+                } else if node.has_tag_name((SKOS, "prefLabel")) {
+                    license.label = node
+                        .text()
+                        .ok_or_else(|| anyhow!("Missing label text"))?
+                        .to_owned();
+                }
+            }
+
+            licenses.push(license);
+        }
+    }
+
+    #[derive(Template)]
+    #[template(path = "licenses.rs", escape = "none")]
+    struct Licenses {
+        licenses: Vec<License>,
+    }
+
+    let licenses = Licenses { licenses }.render().unwrap();
+
+    write(out_dir.join("licenses.rs"), licenses.as_bytes())?;
+
+    println!("cargo:rerun-if-changed=vocabulary/licenses.rdf");
+    println!("cargo:rerun-if-changed=templates/licenses.rs");
+
+    Ok(())
+}
+
+const SKOS: &str = "http://www.w3.org/2004/02/skos/core#";
+
+mod filters {
+    use askama::Result;
+
+    pub fn ident(val: &str) -> Result<String> {
+        Ok(val.replace(&['-', '/', '.'], "_"))
+    }
+}

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -11,6 +11,7 @@ use url::Url;
 pub struct Dataset {
     pub title: String,
     pub description: String,
+    pub license: License,
     pub source_url: Url,
 }
 
@@ -31,3 +32,9 @@ impl Dataset {
         Ok(())
     }
 }
+
+mod licenses {
+    include!(concat!(env!("OUT_DIR"), "/licenses.rs"));
+}
+
+pub use licenses::License;

--- a/src/harvester/ckan.rs
+++ b/src/harvester/ckan.rs
@@ -4,7 +4,10 @@ use futures_util::stream::{iter, StreamExt};
 use reqwest::Client;
 use serde::Deserialize;
 
-use crate::{dataset::Dataset, harvester::Source};
+use crate::{
+    dataset::{Dataset, License},
+    harvester::Source,
+};
 
 pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<()> {
     let rows = source.batch_size;
@@ -99,6 +102,9 @@ async fn write_dataset(dir: &Dir, source: &Source, package: Package) -> Result<(
     let dataset = Dataset {
         title: package.title,
         description: package.notes.unwrap_or_default(),
+        license: package
+            .license_id
+            .map_or(License::Unknown, |license_id| license_id.parse().unwrap()),
         source_url: source
             .source_url()
             .join(&format!("dataset/{}", package.id))?,
@@ -129,6 +135,7 @@ struct Package {
     id: String,
     title: String,
     notes: Option<String>,
+    license_id: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -6,7 +6,10 @@ use quick_xml::de::from_slice;
 use reqwest::{header::CONTENT_TYPE, Client};
 use serde::Deserialize;
 
-use crate::{dataset::Dataset, harvester::Source};
+use crate::{
+    dataset::{Dataset, License},
+    harvester::Source,
+};
 
 pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<()> {
     let max_records = source.batch_size;
@@ -104,6 +107,7 @@ async fn write_dataset(dir: &Dir, source: &Source, record: SummaryRecord) -> Res
     let dataset = Dataset {
         title: record.title,
         description: record.r#abstract,
+        license: License::Unknown,
         source_url: source.source_url().join(&record.identifier)?,
     };
 

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -11,5 +11,7 @@
 
     <p>{{ dataset.description }}</p>
 
+    <p>Lizenz: {{ dataset.license }}</p>
+
   </body>
 </html>

--- a/templates/licenses.rs
+++ b/templates/licenses.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use phf::{Map, phf_map};
 
 #[derive(PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[allow(non_camel_case_types)]
@@ -55,7 +56,11 @@ impl FromStr for License {
     type Err = Infallible;
 
     fn from_str(val: &str) -> Result<Self, Self::Err> {
-        let val = match val {
+        static SYNONYMS: Map<&'static str, &'static str> = phf_map! {
+            "dl-de-by-2.0" => "dl-by-de/2.0",
+        };
+
+        let val = match *SYNONYMS.get(val).unwrap_or(&val) {
             {% for license in licenses %}
 
             "{{ license.identifier }}" => Self::{{ license.identifier|ident }},
@@ -77,6 +82,11 @@ mod tests {
     fn parse_license_identifier() {
         assert_eq!(
             "dl-by-de/2.0".parse::<License>().unwrap(),
+            License::dl_by_de_2_0
+        );
+
+        assert_eq!(
+            "dl-de-by-2.0".parse::<License>().unwrap(),
             License::dl_by_de_2_0
         );
     }

--- a/templates/licenses.rs
+++ b/templates/licenses.rs
@@ -1,0 +1,83 @@
+use std::convert::Infallible;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[allow(non_camel_case_types)]
+pub enum License {
+    {% for license in licenses %}
+
+    {{ license.identifier|ident }},
+
+    {% endfor %}
+
+    Other(String),
+    Unknown,
+}
+
+impl fmt::Debug for License {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let identifier = match self {
+            {% for license in licenses %}
+
+            Self::{{ license.identifier|ident }} => "{{ license.identifier }}",
+
+            {% endfor %}
+
+            Self::Other(_val) => "other",
+            Self::Unknown => "unknown",
+        };
+
+        write!(fmt, "{}", identifier)
+    }
+}
+
+impl fmt::Display for License {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let label = match self {
+            {% for license in licenses %}
+
+            Self::{{ license.identifier|ident }} => "{{ license.label }}",
+
+            {% endfor %}
+
+            Self::Other(val) => val,
+            Self::Unknown => "Unbekannt",
+        };
+
+        write!(fmt, "{}", label)
+    }
+}
+
+impl FromStr for License {
+    type Err = Infallible;
+
+    fn from_str(val: &str) -> Result<Self, Self::Err> {
+        let val = match val {
+            {% for license in licenses %}
+
+            "{{ license.identifier }}" => Self::{{ license.identifier|ident }},
+
+            {% endfor %}
+
+            _ => Self::Other(val.to_owned()),
+        };
+
+        Ok(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_license_identifier() {
+        assert_eq!(
+            "dl-by-de/2.0".parse::<License>().unwrap(),
+            License::dl_by_de_2_0
+        );
+    }
+}

--- a/vocabulary/licenses.rdf
+++ b/vocabulary/licenses.rdf
@@ -1,0 +1,631 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://dcat-ap.de/def/licenses"
+         xml:base="http://dcat-ap.de/def/licenses"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#" 
+         xmlns:dct="http://purl.org/dc/terms/" 
+         xmlns:foaf="http://xmlns.com/foaf/0.1/" 
+         xmlns:owl="http://www.w3.org/2002/07/owl#" 
+         xmlns:org="http://www.w3.org/ns/org#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skos-xl="http://www.w3.org/2008/05/skos-xl#" 
+         xmlns:void="http://rdfs.org/ns/void#" 
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:adms="http://www.w3.org/ns/adms#"
+         >
+  <owl:Ontology rdf:about="http://dcat-ap.de/def/licenses">
+    <owl:versionInfo>20210721</owl:versionInfo>
+    <owl:versionIRI rdf:resource="http://dcat-ap.de/def/licenses/20210721/"/>
+    <rdfs:comment rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Liste der Lizenzen, die im Feld dct:license einer DCAT-AP.de-konformen dcat:distribution für die Zulieferung an GovData erlaubt sind. GovData empfiehlt die Verwendung der Datenlizenz Deutschland 2.0 (Zero oder Namensnennung) sowie der Creative Commons Namensnennung – 4.0 International. Soweit dies nicht möglich sein sollte, wird die Verwendung einer der übrigen zur „freien Nutzung“ ausgewiesenen Lizenzen in der jeweils neuesten Version empfohlen.</rdfs:comment>
+  </owl:Ontology>
+  <skos:ConceptScheme rdf:about="http://dcat-ap.de/def/licenses">
+    <rdfs:label xml:lang="de">Liste der Lizenzen</rdfs:label>
+    <skos:prefLabel xml:lang="de">Liste der Lizenzen</skos:prefLabel>
+    <dct:identifier>http://www.dcat-ap.de/def/licenses</dct:identifier>
+  </skos:ConceptScheme>
+
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/dl-zero-de/2.0">
+    <dc:identifier>dl-zero-de/2.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Datenlizenz Deutschland – Zero – Version 2.0</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Datenlizenz Deutschland – Zero – Version 2.0</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Datenlizenz Deutschland – Zero – Version 2.0</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/dl-zero-de/2.0"/>
+    <skos:altLabel xml:lang="de">dl-zero-de/2.0</skos:altLabel>
+    <dct:references rdf:resource="https://www.govdata.de/dl-de/zero-2-0"/>
+    <foaf:homepage rdf:resource="https://www.govdata.de/dl-de/zero-2-0"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/dl-by-de/2.0">
+    <dc:identifier>dl-by-de/2.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Datenlizenz Deutschland Namensnennung 2.0</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Datenlizenz Deutschland Namensnennung 2.0</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Datenlizenz Deutschland Namensnennung 2.0</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/dl-by-de/2.0"/>
+    <skos:altLabel xml:lang="de">dl-by-de/2.0</skos:altLabel>
+    <dct:references rdf:resource="https://www.govdata.de/dl-de/by-2-0"/>
+    <foaf:homepage rdf:resource="https://www.govdata.de/dl-de/by-2-0"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by/4.0">
+    <dc:identifier>cc-by/4.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung – 4.0 International (CC BY 4.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung – 4.0 International (CC BY 4.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung – 4.0 International (CC BY 4.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by/4.0"/>
+    <skos:altLabel xml:lang="de">cc-by/4.0</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/apache">
+    <dc:identifier>apache</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Freie Softwarelizenz der Apache Software Foundation</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Freie Softwarelizenz der Apache Software Foundation</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Freie Softwarelizenz der Apache Software Foundation</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/apache"/>
+    <skos:altLabel xml:lang="de">apache</skos:altLabel>
+    <dct:references rdf:resource="http://www.apache.org/licenses"/>
+    <foaf:homepage rdf:resource="http://www.apache.org/licenses"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/bsd">
+    <dc:identifier>bsd</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">BSD Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">BSD Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">BSD Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/bsd"/>
+    <skos:altLabel xml:lang="de">bsdlicense</skos:altLabel>
+    <dct:references rdf:resource="http://www.opensource.org/licenses/bsd-license.php"/>
+    <foaf:homepage rdf:resource="http://www.opensource.org/licenses/bsd-license.php"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by">
+    <dc:identifier>cc-by</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung (CC-BY)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung (CC-BY)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung (CC-BY)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by"/>
+    <skos:altLabel xml:lang="de">cc-by</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/cc-by"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/cc-by"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-de/3.0">
+    <dc:identifier>cc-by-de/3.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung 3.0 Deutschland (CC BY 3.0 DE)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung 3.0 Deutschland (CC BY 3.0 DE)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung 3.0 Deutschland (CC BY 3.0 DE)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-de/3.0"/>
+    <skos:altLabel xml:lang="de">cc-by-de/3.0</skos:altLabel>
+    <dct:references rdf:resource="https://creativecommons.org/licenses/by/3.0/de/"/>
+    <foaf:homepage rdf:resource="https://creativecommons.org/licenses/by/3.0/de/"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-sa">
+    <dc:identifier>cc-by-sa</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen (CC-BY-SA)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen (CC-BY-SA)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen (CC-BY-SA)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-sa"/>
+    <skos:altLabel xml:lang="de">cc-by-sa</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/cc-by-sa"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/cc-by-sa"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-sa-de/3.0">
+    <dc:identifier>cc-by-sa-de/3.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Deutschland (CC BY-SA 3.0 DE) </skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Deutschland (CC BY-SA 3.0 DE) </skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 3.0 Deutschland (CC BY-SA 3.0 DE) </rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-sa-de/3.0"/>
+    <skos:altLabel xml:lang="de">cc-by-sa-de/3.0</skos:altLabel>
+    <dct:references rdf:resource="https://creativecommons.org/licenses/by-sa/3.0/de/"/>
+    <foaf:homepage rdf:resource="https://creativecommons.org/licenses/by-sa/3.0/de/"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-sa/4.0">
+    <dc:identifier>cc-by-sa/4.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC-BY-SA 4.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC-BY-SA 4.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC-BY-SA 4.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-sa/4.0"/>
+    <skos:altLabel xml:lang="de">cc-by-sa/4.0</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/ccpdm/1.0">
+    <dc:identifier>ccpdm/1.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Public Domain Mark 1.0 (PDM)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Public Domain Mark 1.0 (PDM)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Public Domain Mark 1.0 (PDM)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/ccpdm/1.0"/>
+    <skos:altLabel xml:lang="de">ccpdm/1.0</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/publicdomain/mark/1.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/publicdomain/mark/1.0/"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-zero">
+    <dc:identifier>cc-zero</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons CC Zero License (cc-zero)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons CC Zero License (cc-zero)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons CC Zero License (cc-zero)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-zero"/>
+    <skos:altLabel xml:lang="de">cc-zero</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/cc-zero"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/cc-zero"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/dl-by-de/1.0">
+    <dc:identifier>dl-by-de/1.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Datenlizenz Deutschland Namensnennung 1.0</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Datenlizenz Deutschland Namensnennung 1.0</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Datenlizenz Deutschland Namensnennung 1.0</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/dl-by-de/1.0"/>
+    <skos:altLabel xml:lang="de">dl-by-de/1.0</skos:altLabel>
+    <dct:references rdf:resource="https://www.govdata.de/dl-de/by-1-0"/>
+    <foaf:homepage rdf:resource="https://www.govdata.de/dl-de/by-1-0"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/geonutz/20130319">
+    <dc:identifier>geonutz/20130319</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Bundes</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Bundes</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Bundes</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/geonutz/20130319"/>
+    <skos:altLabel xml:lang="de">geoNutz/20130319</skos:altLabel>
+    <dct:references rdf:resource="https://sg.geodatenzentrum.de/web_public/gdz/lizenz/geonutzv.pdf"/>
+    <foaf:homepage rdf:resource="https://sg.geodatenzentrum.de/web_public/gdz/lizenz/geonutzv.pdf"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/geoNutz/20131001">
+    <dc:identifier>geoNutz/20131001</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Landes Berlin</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Landes Berlin</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Nutzungsbestimmungen für die Bereitstellung von Geodaten des Landes Berlin</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/geoNutz/20131001"/>
+    <skos:altLabel xml:lang="de">geoNutz/20131001</skos:altLabel>
+    <dct:references rdf:resource="http://www.stadtentwicklung.berlin.de/geoinformation/download/nutzIII.pdf"/>
+    <foaf:homepage rdf:resource="http://www.stadtentwicklung.berlin.de/geoinformation/download/nutzIII.pdf"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/gfdl">
+    <dc:identifier>gfdl</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">GNU Free Documentation License (GFDL)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">GNU Free Documentation License (GFDL)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">GNU Free Documentation License (GFDL)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/gfdl"/>
+    <skos:altLabel xml:lang="de">gfdl</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/gfdl"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/gfdl"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/gpl/3.0">
+    <dc:identifier>gpl/3.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">GNU General Public License version 3.0 (GPLv3)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">GNU General Public License version 3.0 (GPLv3)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">GNU General Public License version 3.0 (GPLv3)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/gpl/3.0"/>
+    <skos:altLabel xml:lang="de">gpl/3.0</skos:altLabel>
+    <dct:references rdf:resource="http://www.opensource.org/licenses/gpl-3.0.html"/>
+    <foaf:homepage rdf:resource="http://www.opensource.org/licenses/gpl-3.0.html"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/mozilla">
+    <dc:identifier>mozilla</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Mozilla Public License 2.0 (MPL)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Mozilla Public License 2.0 (MPL)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Mozilla Public License 2.0 (MPL)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/mozilla"/>
+    <skos:altLabel xml:lang="de">mozilla</skos:altLabel>
+    <dct:references rdf:resource="http://www.mozilla.org/MPL"/>
+    <foaf:homepage rdf:resource="http://www.mozilla.org/MPL"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/odbl">
+    <dc:identifier>odbl</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Open Data Commons Open Database License (ODbL)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Open Data Commons Open Database License (ODbL)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Open Data Commons Open Database License (ODbL)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/odbl"/>
+    <skos:altLabel xml:lang="de">odbl</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/odc-odbl"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/odc-odbl"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/odby">
+    <dc:identifier>odby</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Open Data Commons Attribution License (ODC-BY 1.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Open Data Commons Attribution License (ODC-BY 1.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Open Data Commons Attribution License (ODC-BY 1.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/odby"/>
+    <skos:altLabel xml:lang="de">odby</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/odc-by"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/odc-by"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/odcpddl">
+    <dc:identifier>odcpddl</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Open Data Commons Public Domain Dedication and Licence (ODC PDDL)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Open Data Commons Public Domain Dedication and Licence (ODC PDDL)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Open Data Commons Public Domain Dedication and Licence (ODC PDDL)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/odcpddl"/>
+    <skos:altLabel xml:lang="de">odcpddl</skos:altLabel>
+    <dct:references rdf:resource="http://www.opendefinition.org/licenses/odc-pddl"/>
+    <foaf:homepage rdf:resource="http://www.opendefinition.org/licenses/odc-pddl"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/officialWork">
+    <dc:identifier>officialWork</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Amtliches Werk, lizenzfrei nach §5 Abs. 1 UrhG</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Amtliches Werk, lizenzfrei nach §5 Abs. 1 UrhG</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Amtliches Werk, lizenzfrei nach §5 Abs. 1 UrhG</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/officialWork"/>
+    <skos:altLabel xml:lang="de">officialWork</skos:altLabel>
+    <dct:references rdf:resource="http://www.gesetze-im-internet.de/urhg/__5.html"/>
+    <foaf:homepage rdf:resource="http://www.gesetze-im-internet.de/urhg/__5.html"/>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/other-open">
+    <dc:identifier>other-open</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Andere offene Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Andere offene Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Andere offene Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/other-open"/>
+    <skos:altLabel xml:lang="de">other-open</skos:altLabel>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/other-opensource">
+    <dc:identifier>other-opensource</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Andere Open Source Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Andere Open Source Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Andere Open Source Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/other-opensource"/>
+    <skos:altLabel xml:lang="de">other-opensource</skos:altLabel>
+    <dct:type>Freie Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nc">
+    <dc:identifier>cc-by-nc</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell (CC BY-NC)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell (CC BY-NC)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell (CC BY-NC)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nc"/>
+    <skos:altLabel xml:lang="de">cc-by-nc</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by-nc/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by-nc/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nc-de/3.0">
+    <dc:identifier>cc-by-nc-de/3.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung-Nicht kommerziell 3.0 Deutschland (CC BY-NC 3.0 DE)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung-Nicht kommerziell 3.0 Deutschland (CC BY-NC 3.0 DE)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung-Nicht kommerziell 3.0 Deutschland (CC BY-NC 3.0 DE)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nc-de/3.0"/>
+    <skos:altLabel xml:lang="de">cc-by-nc/3.0</skos:altLabel>
+    <dct:references rdf:resource="https://creativecommons.org/licenses/by-nc/3.0/de/"/>
+    <foaf:homepage rdf:resource="https://creativecommons.org/licenses/by-nc/3.0/de/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nc/4.0">
+    <dc:identifier>cc-by-nc/4.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell 4.0 International (CC BY-NC 4.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell 4.0 International (CC BY-NC 4.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Nicht kommerziell 4.0 International (CC BY-NC 4.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nc/4.0"/>
+    <skos:altLabel xml:lang="de">cc-by-nc/4.0</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nd">
+    <dc:identifier>cc-by-nd</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - Keine Bearbeitung (CC BY-ND)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - Keine Bearbeitung (CC BY-ND)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - Keine Bearbeitung (CC BY-ND)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nd"/>
+    <skos:altLabel xml:lang="de">cc-by-nd</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by-nd/3.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by-nd/3.0/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nd/3.0">
+    <dc:identifier>cc-by-nd/3.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung -- Keine Bearbeitung 3.0 Unported (CC BY-ND 3.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung -- Keine Bearbeitung 3.0 Unported (CC BY-ND 3.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung -- Keine Bearbeitung 3.0 Unported (CC BY-ND 3.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nd/3.0"/>
+    <skos:altLabel xml:lang="de">cc-by-nd/3.0</skos:altLabel>
+    <dct:references rdf:resource="http://creativecommons.org/licenses/by-nd/3.0/"/>
+    <foaf:homepage rdf:resource="http://creativecommons.org/licenses/by-nd/3.0/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/cc-by-nd/4.0">
+    <dc:identifier>cc-by-nd/4.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Creative Commons Namensnennung - - Keine Bearbeitung 4.0 International (CC BY-ND 4.0)</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Creative Commons Namensnennung - - Keine Bearbeitung 4.0 International (CC BY-ND 4.0)</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Creative Commons Namensnennung - - Keine Bearbeitung 4.0 International (CC BY-ND 4.0)</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/cc-by-nd/4.0"/>
+    <skos:altLabel xml:lang="de">cc-by-nd/4.0</skos:altLabel>
+    <dct:references rdf:resource="https://creativecommons.org/licenses/by-nd/4.0/"/>
+    <foaf:homepage rdf:resource="https://creativecommons.org/licenses/by-nd/4.0/"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/dl-by-nc-de/1.0">
+    <dc:identifier>dl-by-nc-de/1.0</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Datenlizenz Deutschland Namensnennung nicht-kommerziell 1.0</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Datenlizenz Deutschland Namensnennung nicht-kommerziell 1.0</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Datenlizenz Deutschland Namensnennung nicht-kommerziell 1.0</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/dl-by-nc-de/1.0"/>
+    <skos:altLabel xml:lang="de">dl-by-nc-de/1.0</skos:altLabel>
+    <dct:references rdf:resource="https://www.govdata.de/dl-de/by-nc-1-0"/>
+    <foaf:homepage rdf:resource="https://www.govdata.de/dl-de/by-nc-1-0"/>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/other-closed">
+    <dc:identifier>other-closed</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Andere geschlossene Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Andere geschlossene Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Andere geschlossene Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/other-closed"/>
+    <skos:altLabel xml:lang="de">other-closed</skos:altLabel>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/other-commercial">
+    <dc:identifier>other-commercial</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Andere kommerzielle Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Andere kommerzielle Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Andere kommerzielle Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/other-commercial"/>
+    <skos:altLabel xml:lang="de">other-commercial</skos:altLabel>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://dcat-ap.de/def/licenses/other-freeware">
+    <dc:identifier>other-freeware</dc:identifier>
+    <skos:topConceptOf rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:inScheme rdf:resource="http://dcat-ap.de/def/licenses"/>
+    <skos:prefLabel xml:lang="de">Andere Freeware Lizenz</skos:prefLabel>
+    <skos-xl:prefLabel>
+      <skos-xl:Label>
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <skos-xl:literalForm xml:lang="de">Andere Freeware Lizenz</skos-xl:literalForm>
+        <rdfs:label xml:lang="de">Andere Freeware Lizenz</rdfs:label>
+      </skos-xl:Label>
+    </skos-xl:prefLabel>
+    <skos:exactMatch rdf:resource="http://dcat-ap.de/def/licenses/other-freeware"/>
+    <skos:altLabel xml:lang="de">other-freeware</skos:altLabel>
+    <dct:type>Eingeschränkte Nutzung</dct:type>
+  </skos:Concept>
+</rdf:RDF>


### PR DESCRIPTION
Using meta programming might be nice to include a compile-time representation of the official DCAT-AP.de vocabulary. On the other hand, this might not be worth as these license identifiers seem to be in rather ad-hoc manners, i.e. it would be more important to be lenient than to have a closed representation.

For example, on `opendata.leipzig.de`, the license is consistently identified by `dl-de-by-2.0` instead of `dl-by-de/2.0`. Hence parsing would need to be much more flexible than just implementing the DCAT-AP.de vocabulary in any case. (But this could for example be handled by a list of license identifier synonyms.)

(It is somewhat unfortunate to have a second XML parser as a build dependency, but it is only a build dependency and `quick-xml` with `serde` cannot disambiguate the namespaced XML tags used by the DCAP-AP.de RDF files.)