### PR TITLE
Add a global limit to in-flight requests and load shedding to the server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cap-primitives"
@@ -1664,6 +1664,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1703,9 +1704,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -1727,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1787,6 +1788,7 @@ dependencies = [
  "tantivy",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 tantivy = "0.18"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs"] }
 toml = "0.5"
+tower = { version = "0.4", features = ["limit", "load-shed"] }
 tower-http = { version = "0.3", features = ["trace"] }
 tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/deployment/server.service
+++ b/deployment/server.service
@@ -7,7 +7,7 @@ RequiresMountsFor=/var/lib/umwelt-info
 [Service]
 User=umwelt-info
 Group=umwelt-info
-Environment=RUST_LOG=info DATA_PATH=/var/lib/umwelt-info BIND_ADDR=0.0.0.0:8080
+Environment=RUST_LOG=info DATA_PATH=/var/lib/umwelt-info BIND_ADDR=0.0.0.0:8080 REQUEST_LIMIT=128
 
 ExecStart=server
 Restart=always


### PR DESCRIPTION
This should prevent excessive load from bringing down the machine just failing some of the connections instead.