### PR TITLE
Optimize binaries for Haswell or later to better utilize our server hardware.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --release
+        env:
+          RUSTFLAGS: -Ctarget-cpu=haswell
       - uses: actions/upload-artifact@v3
         with:
           name: binaries


### PR DESCRIPTION
Our servers report as

```
> cat /proc/cpuinfo
[..]
model name      : Intel Core Processor (Haswell, no TSX, IBRS)
[..]
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt arat md_clear
[..]
```

so this should be the right target CPU flag.