### PR TITLE
Add GeoNetwork harvester based on the Q Search API endpoint.

### DIFF
--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -15,7 +15,7 @@ batch_size = 1000
 
 #[[sources]]
 #name = "geodatenkatalog"
-#type = "csw"
+#type = "geo_network_q"
 #url = "http://gdk.gdi-de.org/gdi-de/srv/ger/csw"
 #source_url = "http://gdk.gdi-de.org/gdi-de/srv/ger/catalog.search#/metadata/{{id}}"
 #concurrency = 5

--- a/src/bin/harvester.rs
+++ b/src/bin/harvester.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use umwelt_info::{
     data_path_from_env,
-    harvester::{ckan, csw, doris_bfs, wasser_de, Config, Source, Type},
+    harvester::{ckan, csw, doris_bfs, geo_network_q, wasser_de, Config, Source, Type},
     metrics::Metrics,
 };
 
@@ -104,6 +104,7 @@ async fn harvest(
         Type::Csw => csw::harvest(&dir, client, &source).await,
         Type::WasserDe => wasser_de::harvest(&dir, client, &source).await,
         Type::DorisBfs => doris_bfs::harvest(&dir, client, &source).await,
+        Type::GeoNetworkQ => geo_network_q::harvest(&dir, client, &source).await,
     };
 
     let (count, transmitted, failed) =

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -85,7 +85,7 @@ async fn fetch_datasets(
     .await?;
 
     let count = response.results.num_records_matched;
-    let results = response.results.num_records_returned;
+    let results = response.results.records.len();
     let mut errors = 0;
 
     for record in response.results.records {
@@ -130,8 +130,6 @@ struct GetRecordsResponse {
 struct SearchResults {
     #[serde(rename = "numberOfRecordsMatched")]
     num_records_matched: usize,
-    #[serde(rename = "numberOfRecordsReturned")]
-    num_records_returned: usize,
     #[serde(rename = "SummaryRecord")]
     records: Vec<SummaryRecord>,
 }

--- a/src/harvester/doris_bfs.rs
+++ b/src/harvester/doris_bfs.rs
@@ -8,7 +8,7 @@ use scraper::{Html, Selector};
 
 use crate::{
     dataset::Dataset,
-    harvester::{with_retry, Source},
+    harvester::{with_retry, write_dataset, Source},
 };
 
 pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usize, usize, usize)> {
@@ -155,11 +155,7 @@ async fn fetch_dataset(dir: &Dir, client: &Client, source: &Source, handle: &str
         source_url: url.into(),
     };
 
-    let file = dir.create(identifier)?;
-
-    dataset.write(file).await?;
-
-    Ok(())
+    write_dataset(dir, identifier, dataset).await
 }
 
 fn parse_count(document: &Html) -> Result<usize> {

--- a/src/harvester/geo_network_q.rs
+++ b/src/harvester/geo_network_q.rs
@@ -1,0 +1,197 @@
+use anyhow::Result;
+use cap_std::fs::Dir;
+use futures_util::stream::{iter, StreamExt};
+use quick_xml::de::from_slice;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::{
+    dataset::Dataset,
+    harvester::{with_retry, Source},
+};
+
+pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usize, usize, usize)> {
+    let entries = source.batch_size;
+
+    let (count, results, errors) = fetch_datasets(dir, client, source, true, 1, entries).await?;
+    tracing::info!("Harvesting {} datasets", count);
+
+    let requests = (count + entries - 1) / entries;
+    let from = (1..requests).map(|request| 1 + request * entries);
+    let to = from.clone().map(|from| from + entries - 1);
+
+    iter(from.zip(to))
+        .map(|(from, to)| fetch_datasets(dir, client, source, false, from, to))
+        .buffer_unordered(source.concurrency)
+        .fold(
+            (results, errors),
+            |(mut results, mut errors), res| async move {
+                match res {
+                    Ok((_count, results1, errors1)) => {
+                        results += results1;
+                        errors += errors1;
+                    }
+                    Err(err) => {
+                        tracing::error!("{:#}", err);
+
+                        errors += 1;
+                    }
+                }
+
+                (results, errors)
+            },
+        )
+        .await;
+
+    Ok((count, results, errors))
+}
+
+#[tracing::instrument(skip(dir, client, source))]
+async fn fetch_datasets(
+    dir: &Dir,
+    client: &Client,
+    source: &Source,
+    summary: bool,
+    from: usize,
+    to: usize,
+) -> Result<(usize, usize, usize)> {
+    tracing::debug!("Fetching datasets from {} to {}", from, to);
+
+    let response = with_retry(|| async {
+        let body = client
+            .get(source.url.clone())
+            .query(&[
+                ("fast", "false"),
+                ("buildSummary", &summary.to_string()),
+                ("from", &from.to_string()),
+                ("to", &to.to_string()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?;
+
+        let response: SearchResults = from_slice(&body)?;
+
+        Ok(response)
+    })
+    .await?;
+
+    let count = if let Some(summary) = response.summary {
+        summary.count.parse()?
+    } else {
+        0
+    };
+
+    let results = response.metadata.len();
+    let mut errors = 0;
+
+    for entry in response.metadata {
+        if let Err(err) = write_dataset(dir, source, entry).await {
+            tracing::error!("{:#}", err);
+
+            errors += 1;
+        }
+    }
+
+    Ok((count, results, errors))
+}
+
+async fn write_dataset(dir: &Dir, source: &Source, entry: Metadata) -> Result<()> {
+    let identifier = entry.file_identifier.text;
+
+    let identification = entry.identification_info.inner.identification();
+    let title = identification.citation.inner.title.text;
+    let description = identification.r#abstract.text.unwrap_or_default();
+
+    let dataset = Dataset {
+        title,
+        description,
+        source_url: source.source_url().replace("{{id}}", &identifier),
+    };
+
+    let file = dir.create(identifier)?;
+
+    dataset.write(file).await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResults {
+    summary: Option<Summary>,
+    #[serde(rename = "MD_Metadata")]
+    metadata: Vec<Metadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Summary {
+    count: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    #[serde(rename = "fileIdentifier")]
+    file_identifier: FileIdentifier,
+    #[serde(rename = "identificationInfo")]
+    identification_info: IdentificationInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileIdentifier {
+    #[serde(rename = "CharacterString")]
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct IdentificationInfo {
+    #[serde(rename = "$value")]
+    inner: IdentificationInfoInner,
+}
+
+#[derive(Debug, Deserialize)]
+enum IdentificationInfoInner {
+    #[serde(rename = "gmd:MD_DataIdentification")]
+    Data(Identification),
+    #[serde(rename = "srv:SV_ServiceIdentification")]
+    Service(Identification),
+}
+
+impl IdentificationInfoInner {
+    fn identification(self) -> Identification {
+        match self {
+            Self::Data(identification) => identification,
+            Self::Service(identification) => identification,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Identification {
+    citation: Citation,
+    r#abstract: Abstract,
+}
+
+#[derive(Debug, Deserialize)]
+struct Abstract {
+    #[serde(rename = "CharacterString")]
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Citation {
+    #[serde(rename = "CI_Citation")]
+    inner: CitationInner,
+}
+
+#[derive(Debug, Deserialize)]
+struct CitationInner {
+    title: Title,
+}
+
+#[derive(Debug, Deserialize)]
+struct Title {
+    #[serde(rename = "CharacterString")]
+    text: String,
+}

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -1,6 +1,7 @@
 pub mod ckan;
 pub mod csw;
 pub mod doris_bfs;
+pub mod geo_network_q;
 pub mod wasser_de;
 
 use std::fmt;
@@ -106,6 +107,7 @@ pub enum Type {
     Ckan,
     Csw,
     WasserDe,
+    GeoNetworkQ,
     DorisBfs,
 }
 

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -15,6 +15,16 @@ use tokio::time::{sleep, Duration};
 use toml::from_str;
 use url::Url;
 
+use crate::dataset::Dataset;
+
+async fn write_dataset(dir: &Dir, id: String, dataset: Dataset) -> Result<()> {
+    let file = dir.create(id)?;
+
+    dataset.write(file).await?;
+
+    Ok(())
+}
+
 async fn with_retry<A, F, T>(mut action: A) -> Result<T>
 where
     A: FnMut() -> F,


### PR DESCRIPTION
This seems nicer than the CSW endpoint provided by GeoNetwork as it returns the full metadata immediately, but it does not seem to be significantly faster based on small tests.

Closes #7 