### PR TITLE
Add xtask infrastructure to simplify local development work flow.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[alias]
+xtask = ["run", "--bin", "xtask", "--"]
+
+[profile.release]
+lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,3 @@ tower-http = { version = "0.3", features = ["trace"] }
 tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.2", features = ["serde"] }
-
-[profile.release]
-lto = "thin"

--- a/deployment/indexer.service
+++ b/deployment/indexer.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=umwelt.info indexer service
+RequiresMountsFor=/var/lib/umwelt-info
+
+[Service]
+User=umwelt-info
+Group=umwelt-info
+Environment=RUST_LOG=info DATA_PATH=/var/lib/umwelt-info
+
+Type=oneshot
+ExecStart=indexer
+
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/umwelt-info
+PrivateDevices=yes
+PrivateTmp=yes
+PrivateUsers=yes
+PrivateNetwork=yes
+NoNewPrivileges=yes
+SystemCallFilter=@system-service

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -1,0 +1,85 @@
+use std::env::args;
+use std::fs::remove_dir_all;
+use std::process::Command;
+
+use anyhow::{anyhow, ensure, Result};
+
+fn main() -> Result<()> {
+    match args().nth(1).as_deref() {
+        None => default(),
+        Some("harvester") => harvester(),
+        Some("indexer") => indexer(),
+        Some("server") => server(),
+        Some(name) => Err(anyhow!("Unknown task {}", name)),
+    }
+}
+
+fn default() -> Result<()> {
+    let status = Command::new("cargo").arg("fmt").status()?;
+
+    ensure!(status.success(), "Rustfmt failed with status {:?}", status);
+
+    let status = Command::new("cargo")
+        .args(["clippy", "--all-targets"])
+        .status()?;
+
+    ensure!(status.success(), "Clippy failed with status {:?}", status);
+
+    let status = Command::new("cargo").arg("test").status()?;
+
+    ensure!(status.success(), "Tests failed with status {:?}", status);
+
+    Ok(())
+}
+
+fn harvester() -> Result<()> {
+    let status = Command::new("cargo")
+        .args(["run", "--bin", "harvester"])
+        .envs([
+            ("DATA_PATH", "data"),
+            ("RUST_LOG", "info,umwelt_info=debug,harvester=debug"),
+        ])
+        .status()?;
+
+    ensure!(
+        status.success(),
+        "Harvester failed with status {:?}",
+        status
+    );
+
+    indexer()?;
+
+    Ok(())
+}
+
+fn indexer() -> Result<()> {
+    let _ = remove_dir_all("data/index");
+
+    let status = Command::new("cargo")
+        .args(["run", "--bin", "indexer"])
+        .envs([
+            ("DATA_PATH", "data"),
+            ("RUST_LOG", "info,umwelt_info=debug,indexer=debug"),
+        ])
+        .status()?;
+
+    ensure!(status.success(), "Indexer failed with status {:?}", status);
+
+    Ok(())
+}
+
+fn server() -> Result<()> {
+    let status = Command::new("cargo")
+        .args(["run", "--bin", "server"])
+        .envs([
+            ("DATA_PATH", "data"),
+            ("BIND_ADDR", "127.0.0.1:8081"),
+            ("REQUEST_LIMIT", "32"),
+            ("RUST_LOG", "info,umwelt_info=debug,server=debug"),
+        ])
+        .status()?;
+
+    ensure!(status.success(), "Server failed with status {:?}", status);
+
+    Ok(())
+}


### PR DESCRIPTION
This should simplify running the programs without shell or batch scripts, e.g. running the harvester (and the indexer) and then the server should be as simple as

```
> cargo xtask harvester
> cargo xtask server
```

with reasonable defaults, e.g. using `data` and listening on `127.0.0.1:8081`.

Furthermore, this as a default action to format, lint and test the code which can be used in edit-compile-test loops invoked as

```
> cargo xtask
```