### PR TITLE
Enable parking_lot usage of tokio and once_cell as we already pull it in via scraper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
 name = "askama"
@@ -1115,6 +1115,9 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "oneshot"
@@ -1732,18 +1735,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2023,12 +2026,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa 1.0.3",
- "js-sys",
  "libc",
  "num_threads",
  "serde",
@@ -2069,6 +2071,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = { version = "0.5", default-features = false, features = ["http1", "query"
 bincode = "1.3"
 cap-std = "0.25"
 futures-util = { version = "0.3", default-features = false }
-once_cell = "1.13"
+once_cell = { version = "1.13", features = ["parking_lot"] }
 hashbrown = { version = "0.12", features = ["serde"] }
 quick-xml = { version = "0.23", features = ["serialize"] }
 rayon = "1.5"
@@ -24,7 +24,7 @@ scraper = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 tantivy = "0.18"
 time = { version = "0.3", features = ["formatting", "macros"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }
 toml = "0.5"
 tower = { version = "0.4", features = ["limit", "load-shed"] }
 tower-http = { version = "0.3", features = ["trace"] }


### PR DESCRIPTION
This usually improves performance due to avoiding the fairness guarantees provided by the standard library's synchronization primitives and while it may not be worth it if it would pull in a new dependency, scraper has already made that choice for us.  