### PR TITLE
Track licenses and collect metrics about them.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,6 +2253,7 @@ dependencies = [
  "futures-util",
  "hashbrown",
  "once_cell",
+ "parking_lot",
  "quick-xml",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cap-std = "0.25"
 futures-util = { version = "0.3", default-features = false }
 once_cell = { version = "1.13", features = ["parking_lot"] }
 hashbrown = { version = "0.12", features = ["serde"] }
+parking_lot = "0.12"
 quick-xml = { version = "0.23", features = ["serialize"] }
 rayon = "1.5"
 regex = "1.6"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -249,6 +249,7 @@ struct MetricsPage<'a> {
     sum_count: usize,
     sum_transmitted: usize,
     sum_failed: usize,
+    licenses: Vec<(String, usize)>,
 }
 
 async fn metrics(Extension(dir): Extension<&'static Dir>) -> Result<Html<String>, ServerError> {
@@ -282,6 +283,14 @@ async fn metrics(Extension(dir): Extension<&'static Dir>) -> Result<Html<String>
             },
         );
 
+        let mut licenses = metrics
+            .licenses
+            .iter()
+            .map(|(license, count)| (license.to_string(), *count))
+            .collect::<Vec<_>>();
+
+        licenses.sort_unstable_by_key(|(_, count)| Reverse(*count));
+
         let page = MetricsPage {
             accesses,
             sum_accesses,
@@ -289,6 +298,7 @@ async fn metrics(Extension(dir): Extension<&'static Dir>) -> Result<Html<String>
             sum_count,
             sum_transmitted,
             sum_failed,
+            licenses,
         };
 
         let page = Html(page.render().unwrap());

--- a/src/dataset/license.rs
+++ b/src/dataset/license.rs
@@ -8,8 +8,22 @@ use serde::{Deserialize, Serialize};
 pub enum License {
     DlDeBy20,
     DlDeZero20,
+    DorisBfs,
     Unknown,
     Other(String),
+}
+
+impl License {
+    pub fn url(&self) -> Option<&'static str> {
+        let val = match self {
+            Self::DlDeBy20 => "https://www.govdata.de/dl-de/by-2-0",
+            Self::DlDeZero20 => "https://www.govdata.de/dl-de/zero-2-0",
+            Self::DorisBfs => "https://doris.bfs.de/jspui/impressum/lizenz.html",
+            Self::Unknown | Self::Other(_) => return None,
+        };
+
+        Some(val)
+    }
 }
 
 impl From<String> for License {
@@ -73,6 +87,7 @@ impl fmt::Display for License {
         let val = match self {
             Self::DlDeBy20 => "dl-by-de/2.0",
             Self::DlDeZero20 => "dl-zero-de/2.0",
+            Self::DorisBfs => "doris-bfs",
             Self::Unknown => "unbekannt",
             Self::Other(val) => val,
         };

--- a/src/dataset/license.rs
+++ b/src/dataset/license.rs
@@ -74,7 +74,7 @@ impl fmt::Display for License {
             Self::DlDeBy20 => "dl-by-de/2.0",
             Self::DlDeZero20 => "dl-zero-de/2.0",
             Self::Unknown => "unbekannt",
-            Self::Other(val) => return write!(fmt, "andere: {val}"),
+            Self::Other(val) => val,
         };
 
         fmt.write_str(val)

--- a/src/dataset/license.rs
+++ b/src/dataset/license.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+
+use hashbrown::HashMap;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum License {
+    DlDeBy20,
+    DlDeZero20,
+    Unknown,
+    Other(String),
+}
+
+impl From<String> for License {
+    fn from(val: String) -> Self {
+        static LICENSES: Lazy<HashMap<&'static str, License>> = Lazy::new(|| {
+            [
+                // Datenlizenz Deutschland – Namensnennung – Version 2.0
+                ("dl-by-de/2.0", License::DlDeBy20),
+                ("dl-de-by-2.0", License::DlDeBy20),
+                (
+                    "http://dcat-ap.de/def/licenses/dl-by-de/2.0",
+                    License::DlDeBy20,
+                ),
+                (
+                    "http://dcat-ap.de/def/licenses/dl-by-de/2_0",
+                    License::DlDeBy20,
+                ),
+                // Datenlizenz Deutschland – Zero – Version 2.0
+                ("dl-zero-de/2.0", License::DlDeZero20),
+                ("dl-de-zero-2.0", License::DlDeZero20),
+                (
+                    "http://dcat-ap.de/def/licenses/dl-zero-de/2.0",
+                    License::DlDeZero20,
+                ),
+                (
+                    "http://dcat-ap.de/def/licenses/dl-zero-de/2_0",
+                    License::DlDeZero20,
+                ),
+            ]
+            .into()
+        });
+
+        if val.is_empty() {
+            return License::Unknown;
+        }
+
+        match LICENSES.get(&*val) {
+            Some(license) => license.clone(),
+            None => Self::Other(val),
+        }
+    }
+}
+
+impl From<&'_ License> for License {
+    fn from(val: &License) -> Self {
+        val.clone()
+    }
+}
+
+impl From<Option<String>> for License {
+    fn from(val: Option<String>) -> Self {
+        match val {
+            Some(val) => val.into(),
+            None => Self::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for License {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let val = match self {
+            Self::DlDeBy20 => "dl-by-de/2.0",
+            Self::DlDeZero20 => "dl-zero-de/2.0",
+            Self::Unknown => "unbekannt",
+            Self::Other(val) => return write!(fmt, "andere: {val}"),
+        };
+
+        fmt.write_str(val)
+    }
+}

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -1,3 +1,5 @@
+mod license;
+
 use std::io::Read;
 
 use anyhow::Result;
@@ -6,10 +8,13 @@ use cap_std::fs::File;
 use serde::{Deserialize, Serialize};
 use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 
+pub use license::License;
+
 #[derive(Deserialize, Serialize)]
 pub struct Dataset {
     pub title: String,
     pub description: String,
+    pub license: License,
     pub source_url: String,
 }
 

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -2,26 +2,34 @@ use anyhow::Result;
 use askama::Template;
 use cap_std::fs::Dir;
 use futures_util::stream::{iter, StreamExt};
+use parking_lot::Mutex;
 use quick_xml::de::from_slice;
 use reqwest::{header::CONTENT_TYPE, Client};
 use serde::Deserialize;
 
 use crate::{
-    dataset::Dataset,
+    dataset::{Dataset, License},
     harvester::{with_retry, write_dataset, Source},
+    metrics::Metrics,
 };
 
-pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usize, usize, usize)> {
+pub async fn harvest(
+    dir: &Dir,
+    client: &Client,
+    metrics: &Mutex<Metrics>,
+    source: &Source,
+) -> Result<(usize, usize, usize)> {
     let max_records = source.batch_size;
 
-    let (count, results, errors) = fetch_datasets(dir, client, source, max_records, 1).await?;
+    let (count, results, errors) =
+        fetch_datasets(dir, client, metrics, source, max_records, 1).await?;
     tracing::info!("Harvesting {} datasets", count);
 
     let requests = (count + max_records - 1) / max_records;
     let start_pos = (1..requests).map(|request| 1 + request * max_records);
 
     let (results, errors) = iter(start_pos)
-        .map(|start_pos| fetch_datasets(dir, client, source, max_records, start_pos))
+        .map(|start_pos| fetch_datasets(dir, client, metrics, source, max_records, start_pos))
         .buffer_unordered(source.concurrency)
         .fold(
             (results, errors),
@@ -46,10 +54,11 @@ pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usi
     Ok((count, results, errors))
 }
 
-#[tracing::instrument(skip(dir, client, source))]
+#[tracing::instrument(skip(dir, client, metrics, source))]
 async fn fetch_datasets(
     dir: &Dir,
     client: &Client,
+    metrics: &Mutex<Metrics>,
     source: &Source,
     max_records: usize,
     start_pos: usize,
@@ -89,7 +98,7 @@ async fn fetch_datasets(
     let mut errors = 0;
 
     for record in response.results.records {
-        if let Err(err) = translate_dataset(dir, source, record).await {
+        if let Err(err) = translate_dataset(dir, metrics, source, record).await {
             tracing::error!("{:#}", err);
 
             errors += 1;
@@ -99,14 +108,20 @@ async fn fetch_datasets(
     Ok((count, results, errors))
 }
 
-async fn translate_dataset(dir: &Dir, source: &Source, record: SummaryRecord) -> Result<()> {
+async fn translate_dataset(
+    dir: &Dir,
+    metrics: &Mutex<Metrics>,
+    source: &Source,
+    record: SummaryRecord,
+) -> Result<()> {
     let dataset = Dataset {
         title: record.title,
         description: record.r#abstract,
+        license: License::Unknown,
         source_url: source.source_url().replace("{{id}}", &record.identifier),
     };
 
-    write_dataset(dir, record.identifier, dataset).await
+    write_dataset(dir, metrics, record.identifier, dataset).await
 }
 
 #[derive(Template)]

--- a/src/harvester/doris_bfs.rs
+++ b/src/harvester/doris_bfs.rs
@@ -2,26 +2,33 @@ use anyhow::{anyhow, ensure, Result};
 use cap_std::fs::Dir;
 use futures_util::stream::{iter, StreamExt};
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
 
 use crate::{
-    dataset::Dataset,
+    dataset::{Dataset, License},
     harvester::{with_retry, write_dataset, Source},
+    metrics::Metrics,
 };
 
-pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usize, usize, usize)> {
+pub async fn harvest(
+    dir: &Dir,
+    client: &Client,
+    metrics: &Mutex<Metrics>,
+    source: &Source,
+) -> Result<(usize, usize, usize)> {
     let rpp = source.batch_size;
 
-    let (count, results, errors) = fetch_datasets(dir, client, source, rpp, 0).await?;
+    let (count, results, errors) = fetch_datasets(dir, client, metrics, source, rpp, 0).await?;
     tracing::info!("Harvesting {} datasets", count);
 
     let requests = (count + rpp - 1) / rpp;
     let offset = (1..requests).map(|request| request * rpp);
 
     let (results, errors) = iter(offset)
-        .map(|offset| fetch_datasets(dir, client, source, rpp, offset))
+        .map(|offset| fetch_datasets(dir, client, metrics, source, rpp, offset))
         .buffer_unordered(source.concurrency)
         .fold(
             (results, errors),
@@ -46,10 +53,11 @@ pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usi
     Ok((count, results, errors))
 }
 
-#[tracing::instrument(skip(dir, client, source))]
+#[tracing::instrument(skip(dir, client, metrics, source))]
 async fn fetch_datasets(
     dir: &Dir,
     client: &Client,
+    metrics: &Mutex<Metrics>,
     source: &Source,
     rpp: usize,
     offset: usize,
@@ -92,7 +100,7 @@ async fn fetch_datasets(
     let mut errors = 0;
 
     for handle in &handles {
-        if let Err(err) = fetch_dataset(dir, client, source, handle).await {
+        if let Err(err) = fetch_dataset(dir, client, metrics, source, handle).await {
             tracing::error!("{:#}", err);
 
             errors += 1;
@@ -102,7 +110,13 @@ async fn fetch_datasets(
     Ok((count, results, errors))
 }
 
-async fn fetch_dataset(dir: &Dir, client: &Client, source: &Source, handle: &str) -> Result<()> {
+async fn fetch_dataset(
+    dir: &Dir,
+    client: &Client,
+    metrics: &Mutex<Metrics>,
+    source: &Source,
+    handle: &str,
+) -> Result<()> {
     tracing::debug!("Fetching dataset at {}", handle);
 
     let url = source.url.join(handle)?;
@@ -152,10 +166,11 @@ async fn fetch_dataset(dir: &Dir, client: &Client, source: &Source, handle: &str
     let dataset = Dataset {
         title,
         description: r#abstract,
+        license: License::Unknown,
         source_url: url.into(),
     };
 
-    write_dataset(dir, identifier, dataset).await
+    write_dataset(dir, metrics, identifier, dataset).await
 }
 
 fn parse_count(document: &Html) -> Result<usize> {

--- a/src/harvester/doris_bfs.rs
+++ b/src/harvester/doris_bfs.rs
@@ -166,7 +166,7 @@ async fn fetch_dataset(
     let dataset = Dataset {
         title,
         description: r#abstract,
-        license: License::Unknown,
+        license: License::DorisBfs,
         source_url: url.into(),
     };
 

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -10,14 +10,20 @@ use std::io::Read;
 
 use anyhow::Result;
 use cap_std::fs::{Dir, OpenOptions as FsOpenOptions};
+use parking_lot::Mutex;
 use serde::Deserialize;
 use tokio::time::{sleep, Duration};
 use toml::from_str;
 use url::Url;
 
-use crate::dataset::Dataset;
+use crate::{dataset::Dataset, metrics::Metrics};
 
-async fn write_dataset(dir: &Dir, id: String, dataset: Dataset) -> Result<()> {
+async fn write_dataset(
+    dir: &Dir,
+    metrics: &Mutex<Metrics>,
+    id: String,
+    dataset: Dataset,
+) -> Result<()> {
     let file = match dir.open_with(&id, FsOpenOptions::new().write(true).create_new(true)) {
         Ok(file) => file,
         Err(_err) => {
@@ -28,6 +34,8 @@ async fn write_dataset(dir: &Dir, id: String, dataset: Dataset) -> Result<()> {
     };
 
     dataset.write(file).await?;
+
+    metrics.lock().record_license(&dataset.license);
 
     Ok(())
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -9,6 +9,7 @@ use tantivy::{
     query::QueryParser,
     schema::{
         Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Value, FAST, STORED,
+        STRING,
     },
     tokenizer::{Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer, TextAnalyzer},
     Document, Index, IndexReader, IndexWriter, Score, SegmentReader,
@@ -30,6 +31,8 @@ fn schema() -> Schema {
 
     schema.add_text_field("title", text.clone());
     schema.add_text_field("description", text);
+
+    schema.add_text_field("license", STRING);
 
     schema.add_u64_field("accesses", FAST);
 
@@ -154,6 +157,8 @@ impl Indexer {
         doc.add_text(self.fields.title, dataset.title);
         doc.add_text(self.fields.description, dataset.description);
 
+        doc.add_text(self.fields.license, dataset.license.to_string());
+
         doc.add_u64(self.fields.accesses, accesses);
 
         self.writer.add_document(doc)?;
@@ -173,6 +178,7 @@ struct Fields {
     id: Field,
     title: Field,
     description: Field,
+    license: Field,
     accesses: Field,
 }
 
@@ -184,6 +190,8 @@ impl Fields {
         let title = schema.get_field("title").unwrap();
         let description = schema.get_field("description").unwrap();
 
+        let license = schema.get_field("license").unwrap();
+
         let accesses = schema.get_field("accesses").unwrap();
 
         Self {
@@ -191,6 +199,7 @@ impl Fields {
             id,
             title,
             description,
+            license,
             accesses,
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,9 +7,12 @@ use cap_std::fs::Dir;
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
+use crate::dataset::License;
+
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Metrics {
     pub harvests: HashMap<String, Harvest>,
+    pub licenses: HashMap<License, usize>,
 }
 
 impl Metrics {
@@ -52,6 +55,10 @@ impl Metrics {
                 failed,
             },
         );
+    }
+
+    pub fn record_license(&mut self, license: &License) {
+        *self.licenses.entry_ref(license).or_default() += 1;
     }
 }
 

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -11,6 +11,8 @@
 
     <p>{{ dataset.description }}</p>
 
+    <p>License: {% if let Some(license_url) = dataset.license.url() %} <a href="{{ license_url }}">{{ dataset.license }}</a> {% else %} {{ dataset.license }} {% endif %}</p>
+
     <p>Accessed {{ accesses }} times.</p>
 
   </body>

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -74,6 +74,11 @@
         </tr>
 
         {% endfor %}
+
+        <tr>
+          <td><b>Other</b></td><td><b>{{ sum_other }}</b></td>
+        </tr>
+
       </tbody>
     </table>
 

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -58,5 +58,24 @@
       </tbody>
     </table>
 
+
+    <h3>Licenses</h3>
+
+    <table>
+      <thead>
+        <th>License</th><th>Count</th>
+      </thead>
+
+      <tbody>
+        {% for (license, count) in licenses %}
+
+        <tr>
+          <td>{{ license }}</td><td>{{ count }}</td>
+        </tr>
+
+        {% endfor %}
+      </tbody>
+    </table>
+
   </body>
 </html>


### PR DESCRIPTION
This is a hand-written alternative to #19 as I am not yet convinced that automatically importing the controlled vocabulary is too helpful as it only applies to what is formally open data. (For example, DORIS has a custom version of CC-BY-NC-SA-3.0 available [at](https://doris.bfs.de/jspui/handle/urn:nbn:de:0221-2022012530627#) which we would need to link even though the license will likely never be part of the DCAT-AP.de vocabulary.) 

Just this tiny bit of code already handles most datasets where these is a dataset-level license defined:

![grafik](https://user-images.githubusercontent.com/12997846/183221568-d25d1c0e-4a63-4de4-8407-b338d5fa8e17.png)

Of course, it also looks like most datasets only have resource-level license information which is the main problem here. I think a heuristic that infers the license by looking if all resources have the same license attached might be helpful as a next step (and of course, extending the other harvesters to gather license information).

Another useful next step would be to make the licenses searchable, either by their ID or by their name or properly using faceted search.

In any case, the metrics already provide a useful goal to work on improving thing IMHO.