### PR TITLE
Use the Accept header to perform content negotiation for the search and dataset routes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 anyhow = "1.0"
 askama = { version = "0.11", default-features = false, features = ["urlencode"] }
 async-compression = { version = "0.3", features = ["tokio", "zstd"] }
-axum = { version = "0.5", default-features = false, features = ["http1", "query", "tower-log"] }
+axum = { version = "0.5", default-features = false, features = ["http1", "query", "json", "tower-log"] }
 bincode = "1.3"
 bytes = "1.2"
 cap-std = "0.25"

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ under which its response is stored on disk. Once development has reached a state
 ```console
 > REPLAY_RESPONSES= cargo xtask harvester
 ```
+
+### Content negotiation
+
+The HTTP routes `/search` and `/dataset` support content negotiation insofar they yield either rendered HTML pages or the underlying JSON data depending on the `Accept` header transmitted by the HTTP client.

--- a/src/index.rs
+++ b/src/index.rs
@@ -26,7 +26,7 @@ fn schema() -> Schema {
 
     let mut schema = Schema::builder();
 
-    schema.add_text_field("source", STORED);
+    schema.add_text_field("source", STRING | STORED);
     schema.add_text_field("id", STORED);
 
     schema.add_text_field("title", text.clone());

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,10 @@
 use std::io::{BufReader, Write};
-use std::sync::Mutex;
 
 use anyhow::Result;
 use bincode::config::{DefaultOptions, Options};
 use cap_std::fs::Dir;
 use hashbrown::HashMap;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -28,7 +28,7 @@ impl Stats {
     pub fn write(this: &Mutex<Self>, dir: &Dir) -> Result<()> {
         let buf = DefaultOptions::new()
             .with_fixint_encoding()
-            .serialize(&*this.lock().unwrap())?;
+            .serialize(&*this.lock())?;
 
         let mut file = dir.create("stats.new")?;
         file.write_all(&buf)?;

--- a/templates/search.html
+++ b/templates/search.html
@@ -21,9 +21,9 @@
     {% for result in results %}
 
     <div>
-      <h2><a href="/dataset/{{ result.source }}/{{ result.id }}">{{ result.title }}</a></h2>
+      <h2><a href="/dataset/{{ result.source }}/{{ result.id }}">{{ result.dataset.title }}</a></h2>
 
-      <p>{{ result.description }}</p>
+      <p>{{ result.dataset.description }}</p>
     </div>
 
     {% endfor %}


### PR DESCRIPTION
This means our server doubles up as a website and an API. Even an undocumented and unversioned API should be useful for us to perform one-off data analyses using e.g. Python scripts.