### PR TITLE
Disable usage of LZ4 compression in the index as our index will comfortably fit into memory for the forseeable future.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,12 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c038063f7a78126c539d666a0323a2032de5e7366012cd14a6eafc5ba290bbd6"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,7 +1894,6 @@ dependencies = [
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
  "measure_time",
  "memmap2",
  "murmurhash32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 scraper = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-tantivy = "0.18"
+tantivy = { version = "0.18", default-features = false, features = ["mmap"] }
 time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }
 toml = "0.5"


### PR DESCRIPTION
This is a counter-point to #16 which instead of applying it to the datasets as well, disables it for the index. This is reasonable insofar both our index and our datasets currently fit comfortably into the main memory of our server which means we are not really avoid additional IO operations by compression and needlessly decompress page cache contents instead.

Fixes #3