### PR TITLE
Retrieve full records in the CSW harvester and unify the record parsing with the GeoNetworkQ harvester.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,16 +1385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9279fbdacaad3baf559d8cabe0acc3d06e30ea14931af31af79578ac0946decc"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2247,12 +2249,12 @@ dependencies = [
  "hashbrown",
  "once_cell",
  "parking_lot",
- "quick-xml",
  "rayon",
  "regex",
  "reqwest",
  "scraper",
  "serde",
+ "serde-xml-rs",
  "tantivy",
  "time",
  "tokio",
@@ -2581,3 +2583,9 @@ dependencies = [
  "io-lifetimes",
  "windows-sys",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "askama"
@@ -106,9 +106,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -248,9 +248,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "combine"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "memchr",
 ]
@@ -556,36 +556,36 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -871,9 +871,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "linux-raw-sys"
@@ -987,9 +987,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -1309,18 +1309,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1586,6 +1586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112908c3ac4711a1554b3948432ecaf5f061a951aa326977b63f7f72a86a4c0e"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,15 +1737,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
-version = "0.5.1"
+name = "serde-roxmltree"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+checksum = "e1d3f79c0a1fc20a3e79c32951833f895bdd169f51b5913635654441010a40ca"
 dependencies = [
- "log",
+ "roxmltree",
  "serde",
- "thiserror",
- "xml-rs",
 ]
 
 [[package]]
@@ -2254,7 +2261,7 @@ dependencies = [
  "reqwest",
  "scraper",
  "serde",
- "serde-xml-rs",
+ "serde-roxmltree",
  "tantivy",
  "time",
  "tokio",
@@ -2585,7 +2592,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.4"
+name = "xmlparser"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ futures-util = { version = "0.3", default-features = false }
 once_cell = { version = "1.13", features = ["parking_lot"] }
 hashbrown = { version = "0.12", features = ["serde"] }
 parking_lot = "0.12"
-quick-xml = { version = "0.23", features = ["serialize"] }
 rayon = "1.5"
 regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 scraper = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
+serde-xml-rs = "0.5"
 tantivy = { version = "0.18", default-features = false, features = ["mmap"] }
 time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 scraper = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde-xml-rs = "0.5"
+serde-roxmltree = "0.2"
 tantivy = { version = "0.18", default-features = false, features = ["mmap"] }
 time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }

--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -17,6 +17,7 @@ batch_size = 1000
 #name = "geodatenkatalog"
 #type = "geo_network_q"
 #url = "http://gdk.gdi-de.org/gdi-de/srv/ger/q"
+#filter = "environment"
 #source_url = "http://gdk.gdi-de.org/gdi-de/srv/ger/catalog.search#/metadata/{{id}}"
 #concurrency = 5
 

--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -16,14 +16,14 @@ batch_size = 1000
 #[[sources]]
 #name = "geodatenkatalog"
 #type = "geo_network_q"
-#url = "http://gdk.gdi-de.org/gdi-de/srv/ger/csw"
+#url = "http://gdk.gdi-de.org/gdi-de/srv/ger/q"
 #source_url = "http://gdk.gdi-de.org/gdi-de/srv/ger/catalog.search#/metadata/{{id}}"
 #concurrency = 5
 
 [[sources]]
 name = "uba-gdi"
 type = "csw"
-url = "https://gis.uba.de/smartfinder-csw/api/"
+url = "https://gis.uba.de/smartfinder-csw/api"
 source_url = "https://gis.uba.de/smartfinder-client/?lang=de#/datasets/iso/{{id}}"
 
 [[sources]]

--- a/src/harvester/ckan.rs
+++ b/src/harvester/ckan.rs
@@ -5,7 +5,7 @@ use anyhow::{ensure, Result};
 use cap_std::fs::Dir;
 use futures_util::stream::{iter, StreamExt};
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     dataset::Dataset,
@@ -59,10 +59,16 @@ async fn fetch_datasets(
 
     let url = source.url.join("api/3/action/package_search")?;
 
+    #[derive(Serialize)]
+    struct Params {
+        start: usize,
+        rows: usize,
+    }
+
     let response = with_retry(|| async {
         let response = client
             .get(url.clone())
-            .query(&[("start", start.to_string()), ("rows", rows.to_string())])
+            .query(&Params { start, rows })
             .send()
             .await?
             .error_for_status()?

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -4,7 +4,7 @@ use cap_std::fs::Dir;
 use futures_util::stream::{iter, StreamExt};
 use reqwest::{header::CONTENT_TYPE, Client};
 use serde::Deserialize;
-use serde_xml_rs::from_str;
+use serde_roxmltree::from_str;
 
 use crate::{
     dataset::{Dataset, License},

--- a/src/harvester/doris_bfs.rs
+++ b/src/harvester/doris_bfs.rs
@@ -5,6 +5,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
+use serde::Serialize;
 
 use crate::{
     dataset::{Dataset, License},
@@ -58,10 +59,16 @@ async fn fetch_datasets(
 
     let url = source.url.join("/jspui/browse")?;
 
+    #[derive(Serialize)]
+    struct Params {
+        rpp: usize,
+        offset: usize,
+    }
+
     let response = with_retry(|| async {
         let response = client
             .get(url.clone())
-            .query(&[("rpp", &rpp.to_string()), ("offset", &offset.to_string())])
+            .query(&Params { rpp, offset })
             .send()
             .await?
             .error_for_status()?

--- a/src/harvester/geo_network_q.rs
+++ b/src/harvester/geo_network_q.rs
@@ -17,7 +17,7 @@ pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usi
     let from = (1..requests).map(|request| 1 + request * entries);
     let to = from.clone().map(|from| from + entries - 1);
 
-    iter(from.zip(to))
+    let (results, errors) = iter(from.zip(to))
         .map(|(from, to)| fetch_datasets(dir, client, source, false, from, to))
         .buffer_unordered(source.concurrency)
         .fold(

--- a/src/harvester/geo_network_q.rs
+++ b/src/harvester/geo_network_q.rs
@@ -3,7 +3,7 @@ use cap_std::fs::Dir;
 use futures_util::stream::{iter, StreamExt};
 use reqwest::Client;
 use serde::Deserialize;
-use serde_xml_rs::from_str;
+use serde_roxmltree::from_str;
 
 use crate::harvester::{csw, with_retry, Source};
 

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -81,6 +81,7 @@ pub struct Source {
     pub name: String,
     pub r#type: Type,
     url: Url,
+    filter: Option<String>,
     source_url: Option<String>,
     #[serde(default = "default_concurrency")]
     concurrency: usize,
@@ -106,14 +107,25 @@ impl Source {
 
 impl fmt::Debug for Source {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let Self {
+            name,
+            r#type,
+            url,
+            filter,
+            source_url,
+            concurrency,
+            batch_size,
+        } = self;
+
         fmt.debug_struct("Source")
-            .field("name", &self.name)
-            .field("type", &self.r#type)
+            .field("name", name)
+            .field("type", r#type)
             // The default format of `Url` is too verbose for the logs.
-            .field("url", &self.url.as_str())
-            .field("source_url", &self.source_url)
-            .field("concurrency", &self.concurrency)
-            .field("batch_size", &self.batch_size)
+            .field("url", &url.as_str())
+            .field("filter", filter)
+            .field("source_url", source_url)
+            .field("concurrency", concurrency)
+            .field("batch_size", batch_size)
             .finish()
     }
 }

--- a/templates/csw_get_records.xml
+++ b/templates/csw_get_records.xml
@@ -2,12 +2,12 @@
 
 <csw:GetRecords
     xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-    xmlns:gmd="http://www.isotc211.org/2005/gmd"
     service="CSW"
     version="2.0.2"
     resultType="results"
+    outputSchema="csw:Record"
     maxRecords="{{ max_records }}"
     startPosition="{{ start_pos }}"
 >
-    <csw:Query typeNames="gmd:MD_Metadata" />
+    <csw:Query typeNames="csw:Record" />
 </csw:GetRecords>


### PR DESCRIPTION
Interestingly GeoNetwork's Q search API seems to just return the same CSW-based record format so that we can avoid parsing it twice. 🎉 

We do have to switch XML parsers for now though, as the current version of `quick-xml` is unable to handle the namespacing employed in these formats. `serde-xml-rs` is measurably slower, but being incorrect and fast is relatively useless. It should also be straight forward to switch to another `serde`-based XML parser in the future, e.g. a fixed version of `quick-xml`. (This is also really only relevant if the XML parser actually becomes a performance bottleneck in the future.)

Fixes #49 