### PR TITLE
Provide an efficient tag representation

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -16,7 +16,7 @@ use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 pub use contact::Contact;
 pub use license::License;
 pub use resource::{Resource, Type as ResourceType};
-pub use tag::{Tag, TagExt};
+pub use tag::Tag;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Dataset {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -1,6 +1,7 @@
 mod contact;
 mod license;
 mod resource;
+mod tag;
 
 use std::io::Read;
 
@@ -15,6 +16,7 @@ use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 pub use contact::Contact;
 pub use license::License;
 pub use resource::{Resource, Type as ResourceType};
+pub use tag::{Tag, TagExt};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Dataset {
@@ -23,7 +25,7 @@ pub struct Dataset {
     pub comment: Option<String>,
     pub license: License,
     pub contacts: Vec<Contact>,
-    pub tags: Vec<String>,
+    pub tags: Vec<Tag>,
     pub region: Option<String>,
     pub issued: Option<Date>,
     pub last_checked: Option<Date>,
@@ -63,7 +65,7 @@ impl Dataset {
                     comment: None,
                     license: old_val.license,
                     contacts: Vec::new(),
-                    tags: old_val.tags,
+                    tags: old_val.tags.into_iter().map(Into::into).collect(),
                     region: None,
                     issued: old_val.issued,
                     last_checked: None,

--- a/src/dataset/tag.rs
+++ b/src/dataset/tag.rs
@@ -44,7 +44,7 @@ impl fmt::Display for Tag {
 }
 
 impl Tag {
-    fn with_tokens<F>(&self, f: F)
+    pub fn with_tokens<F>(&self, f: F)
     where
         F: FnOnce(&[&str]),
     {
@@ -65,77 +65,5 @@ impl Tag {
         };
 
         f(val)
-    }
-}
-
-pub trait TagExt {
-    fn join_tokens(&self, separator: &str) -> String;
-}
-
-impl TagExt for [Tag] {
-    fn join_tokens(&self, separator: &str) -> String {
-        let mut val = String::new();
-
-        let mut tags = self.iter();
-
-        if let Some(tag) = tags.next() {
-            tag.with_tokens(|tokens| {
-                let mut tokens = tokens.iter();
-
-                if let Some(token) = tokens.next() {
-                    val.push_str(token);
-                }
-
-                for token in tokens {
-                    val.push_str(separator);
-                    val.push_str(token);
-                }
-            });
-        }
-
-        for tag in tags {
-            tag.with_tokens(|tokens| {
-                for token in tokens {
-                    val.push_str(separator);
-                    val.push_str(token);
-                }
-            });
-        }
-
-        val
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn join_single_tag_single_token() {
-        assert_eq!([Tag::from("foobar")].join_tokens(", "), "foobar");
-    }
-
-    #[test]
-    fn join_single_tag_multiple_tokens() {
-        assert_eq!(
-            [Tag::Wrrl].join_tokens(", "),
-            "WRRL, Wasserrahmenrichtlinie, Wasserrahmen-Richtlinie"
-        );
-    }
-
-    #[test]
-    fn join_multiple_tags_single_token() {
-        assert_eq!(
-            [Tag::from("foo"), Tag::from("bar")].join_tokens(", "),
-            "foo, bar"
-        );
-    }
-
-    #[test]
-    fn join_multiple_tags_multiple_tokens() {
-        assert_eq!(
-            [Tag::Wrrl, Tag::HwrmRl].join_tokens(", "),
-            "WRRL, Wasserrahmenrichtlinie, Wasserrahmen-Richtlinie, HWRM-RL, Hochwasserrisikomanagement-Richtlinie, Hochwasserrisikomanagementrichtlinie"
-        );
     }
 }

--- a/src/dataset/tag.rs
+++ b/src/dataset/tag.rs
@@ -11,6 +11,12 @@ pub enum Tag {
     BgRl,
 }
 
+impl From<&'_ Tag> for Tag {
+    fn from(val: &Tag) -> Self {
+        val.clone()
+    }
+}
+
 impl From<String> for Tag {
     fn from(val: String) -> Self {
         Self::Other(val)

--- a/src/dataset/tag.rs
+++ b/src/dataset/tag.rs
@@ -1,0 +1,135 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum Tag {
+    Other(String),
+    Wrrl,
+    HwrmRl,
+    MsrRl,
+    BgRl,
+}
+
+impl From<String> for Tag {
+    fn from(val: String) -> Self {
+        Self::Other(val)
+    }
+}
+
+impl From<&'_ str> for Tag {
+    fn from(val: &str) -> Self {
+        val.to_owned().into()
+    }
+}
+
+impl fmt::Display for Tag {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let val = match self {
+            Self::Other(val) => val,
+            Self::Wrrl => "WRRL",
+            Self::HwrmRl => "HWRM-RL",
+            Self::MsrRl => "MSR-RL",
+            Self::BgRl => "BG-RL",
+        };
+
+        fmt.write_str(val)
+    }
+}
+
+impl Tag {
+    fn with_tokens<F>(&self, f: F)
+    where
+        F: FnOnce(&[&str]),
+    {
+        let val = match self {
+            Self::Other(val) => return f(&[val]),
+            Self::Wrrl => &["WRRL", "Wasserrahmenrichtlinie", "Wasserrahmen-Richtlinie"],
+            Self::HwrmRl => &[
+                "HWRM-RL",
+                "Hochwasserrisikomanagement-Richtlinie",
+                "Hochwasserrisikomanagementrichtlinie",
+            ],
+            Self::MsrRl => &[
+                "MSR-RL",
+                "Meeresstrategie-Rahmenrichtlinie",
+                "Meeresstrategierahmenrichtlinie",
+            ],
+            Self::BgRl => &["BG-RL", "Badegewässer-Richtlinie", "Badegewässerrichtlinie"],
+        };
+
+        f(val)
+    }
+}
+
+pub trait TagExt {
+    fn join_tokens(&self, separator: &str) -> String;
+}
+
+impl TagExt for [Tag] {
+    fn join_tokens(&self, separator: &str) -> String {
+        let mut val = String::new();
+
+        let mut tags = self.iter();
+
+        if let Some(tag) = tags.next() {
+            tag.with_tokens(|tokens| {
+                let mut tokens = tokens.iter();
+
+                if let Some(token) = tokens.next() {
+                    val.push_str(token);
+                }
+
+                for token in tokens {
+                    val.push_str(separator);
+                    val.push_str(token);
+                }
+            });
+        }
+
+        for tag in tags {
+            tag.with_tokens(|tokens| {
+                for token in tokens {
+                    val.push_str(separator);
+                    val.push_str(token);
+                }
+            });
+        }
+
+        val
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_single_tag_single_token() {
+        assert_eq!([Tag::from("foobar")].join_tokens(", "), "foobar");
+    }
+
+    #[test]
+    fn join_single_tag_multiple_tokens() {
+        assert_eq!(
+            [Tag::Wrrl].join_tokens(", "),
+            "WRRL, Wasserrahmenrichtlinie, Wasserrahmen-Richtlinie"
+        );
+    }
+
+    #[test]
+    fn join_multiple_tags_single_token() {
+        assert_eq!(
+            [Tag::from("foo"), Tag::from("bar")].join_tokens(", "),
+            "foo, bar"
+        );
+    }
+
+    #[test]
+    fn join_multiple_tags_multiple_tokens() {
+        assert_eq!(
+            [Tag::Wrrl, Tag::HwrmRl].join_tokens(", "),
+            "WRRL, Wasserrahmenrichtlinie, Wasserrahmen-Richtlinie, HWRM-RL, Hochwasserrisikomanagement-Richtlinie, Hochwasserrisikomanagementrichtlinie"
+        );
+    }
+}

--- a/src/harvester/wasser_de.rs
+++ b/src/harvester/wasser_de.rs
@@ -36,7 +36,7 @@ use smallvec::smallvec;
 use time::{macros::format_description, Date};
 
 use crate::{
-    dataset::{Contact, Dataset, Resource},
+    dataset::{Contact, Dataset, Resource, Tag},
     harvester::{client::Client, write_dataset, Source},
 };
 
@@ -189,25 +189,21 @@ struct Document {
 }
 
 impl Document {
-    fn tags(&self) -> Vec<String> {
+    fn tags(&self) -> Vec<Tag> {
         let mut tags = Vec::new();
 
         if let Some(directive) = &self.directive {
             if directive.contains("1#") {
-                tags.push("WRRL".to_owned());
-                tags.push("Wasserrahmenrichtlinie".to_owned());
+                tags.push(Tag::Wrrl);
             }
             if directive.contains("2#") {
-                tags.push("HWRM-RL".to_owned());
-                tags.push("Hochwasserrisikomanagement-Richtlinie".to_owned());
+                tags.push(Tag::HwrmRl);
             }
             if directive.contains("3#") {
-                tags.push("MSR-RL".to_owned());
-                tags.push("Meeresstrategie-Rahmenrichtlinie".to_owned());
+                tags.push(Tag::MsrRl);
             }
             if directive.contains("4#") {
-                tags.push("BG-RL".to_owned());
-                tags.push("Badegewässer-Richtlinie".to_owned());
+                tags.push(Tag::BgRl);
             }
         }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -15,7 +15,7 @@ use tantivy::{
     Document, Index, IndexReader, IndexWriter, Score, SegmentReader,
 };
 
-use crate::dataset::Dataset;
+use crate::dataset::{Dataset, TagExt};
 
 fn schema() -> Schema {
     let text = TextOptions::default().set_indexing_options(
@@ -170,7 +170,7 @@ impl Indexer {
 
         doc.add_text(self.fields.license, dataset.license.to_string());
 
-        doc.add_text(self.fields.tags, dataset.tags.join(" "));
+        doc.add_text(self.fields.tags, dataset.tags.join_tokens(" "));
 
         doc.add_u64(self.fields.accesses, accesses);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,12 +7,13 @@ use cap_std::fs::Dir;
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::dataset::{Dataset, License};
+use crate::dataset::{Dataset, License, Tag};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Metrics {
     pub harvests: HashMap<String, Harvest>,
     pub licenses: HashMap<String, HashMap<License, usize>>,
+    pub tags: HashMap<Tag, usize>,
 }
 
 impl Metrics {
@@ -59,6 +60,7 @@ impl Metrics {
 
     pub fn clear_datasets(&mut self) {
         self.licenses.clear();
+        self.tags.clear();
     }
 
     pub fn record_dataset(&mut self, source: &str, dataset: &Dataset) {
@@ -68,6 +70,10 @@ impl Metrics {
             .or_default()
             .entry_ref(&dataset.license)
             .or_default() += 1;
+
+        for tag in &dataset.tags {
+            *self.tags.entry_ref(tag).or_default() += 1;
+        }
     }
 }
 

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -81,7 +81,7 @@
           {% endfor %}
 
           <tr>
-            <td><b>Other</b></td><td><b>{{ sum_other }}</b></td>
+            <td><b>Other</b></td><td><b>{{ sum_other_licenses }}</b></td>
           </tr>
 
         </tbody>
@@ -107,6 +107,32 @@
 
         </tbody>
       </table>
+    </details>
+
+
+    <details>
+      <summary>Tags</summary>
+  
+      <table>
+        <thead>
+          <th>Tag</th><th>Count</th>
+        </thead>
+  
+        <tbody>
+          {% for (tag, count) in tags %}
+  
+          <tr>
+            <td>{{ tag }}</td><td>{{ count }}</td>
+          </tr>
+  
+          {% endfor %}
+  
+          <tr>
+            <td><b>Other</b></td><td><b>{{ sum_other_tags }}</b></td>
+          </tr>
+  
+          </tbody>
+        </table>
     </details>
 
   </body>


### PR DESCRIPTION
This is a follow-up to #63 and avoids allocations and folds synonyms for known tags while supporting arbitrary tags.