### PR TITLE
Start adding scripts to make ad-hoc analyses on the metadata catalogue.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- --deny warnings --forbid unsafe-code
+      - run: |
+          pip install black flake8
+          black --check analysis
+          flake8 analysis
+
 
   test:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /data
+__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,6 +1846,9 @@ name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2292,6 +2295,7 @@ dependencies = [
  "serde",
  "serde-roxmltree",
  "serde_json",
+ "smallvec",
  "tantivy",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ scraper = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-roxmltree = "0.3"
+smallvec = { version = "1.9", features = ["union", "const_generics", "serde"] }
 tantivy = { version = "0.18", default-features = false, features = ["mmap"] }
 time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }

--- a/analysis/fetch.py
+++ b/analysis/fetch.py
@@ -1,0 +1,34 @@
+import requests
+
+
+DEFAULT_URL = "http://localhost:8081/search"
+DEFAULT_QUERY = "*"
+
+session = requests.Session()
+
+
+def _fetch_page(page, /, url, query):
+    global session
+
+    response = session.get(
+        url,
+        params={"query": query, "page": page, "results_per_page": 100},
+        headers={"accept": "application/json"},
+    )
+
+    response.raise_for_status()
+
+    return response.json()
+
+
+def fetch(*, url=DEFAULT_URL, query=DEFAULT_QUERY):
+    results = _fetch_page(1, url, query)
+
+    for result in results["results"]:
+        yield result["source"], result["id"], result["dataset"]
+
+    for page in range(2, results["pages"] + 1):
+        results = _fetch_page(page, url, query)
+
+        for result in results["results"]:
+            yield result["source"], result["id"], result["dataset"]

--- a/analysis/resources.py
+++ b/analysis/resources.py
@@ -1,0 +1,17 @@
+import collections
+
+from fetch import fetch
+
+
+histogram = collections.Counter()
+
+for (_source, _id, dataset) in fetch():
+    histogram[len(dataset["resources"])] += 1
+
+total = histogram.total()
+cumsum = 0
+
+for (resources, count) in histogram.most_common():
+    cumsum += count
+
+    print(f"{resources}: {100 * cumsum/ total:.1f} %")

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use bincode::{deserialize, serialize};
 use cap_std::fs::File;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use time::Date;
 use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 
@@ -20,7 +21,7 @@ pub struct Dataset {
     pub license: License,
     pub tags: Vec<String>,
     pub source_url: String,
-    pub resources: Vec<Resource>,
+    pub resources: SmallVec<[Resource; 4]>,
     pub issued: Option<Date>,
 }
 
@@ -44,13 +45,13 @@ impl Dataset {
                     .map_err(|_old_err| err)
                     .context("Failed to deserialize dataset")?;
 
-                Dataset {
+                Self {
                     title: old_val.title,
                     description: old_val.description,
                     license: old_val.license,
                     tags: Vec::new(),
                     source_url: old_val.source_url,
-                    resources: Vec::new(),
+                    resources: SmallVec::new(),
                     issued: None,
                 }
             }

--- a/src/harvester/csw.rs
+++ b/src/harvester/csw.rs
@@ -7,6 +7,7 @@ use reqwest::header::CONTENT_TYPE;
 use serde::Deserialize;
 use serde_json::from_str as from_json_str;
 use serde_roxmltree::{from_doc as from_xml_doc, roxmltree::Document};
+use smallvec::SmallVec;
 
 use crate::{
     dataset::Dataset,
@@ -100,7 +101,7 @@ pub async fn translate_dataset(dir: &Dir, source: &Source, record: Record<'_>) -
         license,
         tags: Vec::new(),
         source_url: source.source_url().replace("{{id}}", identifier),
-        resources: Vec::new(),
+        resources: SmallVec::new(),
         issued: None,
     };
 

--- a/src/harvester/doris_bfs.rs
+++ b/src/harvester/doris_bfs.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use scraper::{Html, Selector};
 use serde::Serialize;
+use smallvec::SmallVec;
 
 use crate::{
     dataset::{Dataset, License},
@@ -150,7 +151,7 @@ async fn fetch_dataset(dir: &Dir, client: &Client, source: &Source, handle: &str
         license: License::DorisBfs,
         tags: Vec::new(),
         source_url: url.into(),
-        resources: Vec::new(),
+        resources: SmallVec::new(),
         issued: None,
     };
 

--- a/src/harvester/wasser_de.rs
+++ b/src/harvester/wasser_de.rs
@@ -18,6 +18,7 @@ use anyhow::{anyhow, Result};
 use cap_std::fs::Dir;
 use serde::{Deserialize, Serialize};
 use serde_json::from_slice;
+use smallvec::smallvec;
 use time::Date;
 
 use crate::{
@@ -84,7 +85,7 @@ async fn translate_dataset(dir: &Dir, source: &Source, document: Document) -> Re
         license: document.license.as_str().into(),
         tags,
         source_url: source.url.clone().into(),
-        resources: vec![Resource::unknown(document.url)],
+        resources: smallvec![Resource::unknown(document.url)],
         issued,
     };
 


### PR DESCRIPTION
Such analyses can for example be used to make decisions on software optimizations like in the second commit included here.

The analysis itself finishes in about 10 seconds when running against a local release build of the server and a catalogue of 65k datasets:

```console
> time python3 resources.py 
1: 36.0 %
2: 59.4 %
3: 69.0 %
4: 78.1 %
0: 87.0 %
5: 94.5 %
13: 96.1 %
6: 97.1 %
8: 97.6 %
9: 98.1 %
...
44: 100.0 %
57: 100.0 %
84: 100.0 %
61: 100.0 %
65: 100.0 %

real    0m8,661s
user    0m1,306s
sys     0m0,043s
```

Fetching the same amount of data over an SSH tunnel from our server takes a bit more than minute and produces between 20% and 30% CPU utilization on that server.