### PR TITLE
Add a rudimentary SmartFinder harvester to handle the BfG's Geoportal.

### DIFF
--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -38,3 +38,9 @@ type = "doris_bfs"
 url = "https://doris.bfs.de/"
 batch_size = 10
 concurrency = 5
+
+[[sources]]
+name = "geodatenkatalog-bfg"
+type = "smart_finder"
+url = "https://geoportal.bafg.de/smartfinderServer/iso/select"
+source_url = "https://geoportal.bafg.de/smartfinderClient/js/apps/portal-integration/index.html?lang=de#/datasets/iso/{{id}}"

--- a/src/bin/harvester.rs
+++ b/src/bin/harvester.rs
@@ -10,7 +10,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use umwelt_info::{
     data_path_from_env,
     harvester::{
-        ckan, client::Client, csw, doris_bfs, geo_network_q, wasser_de, Config, Source, Type,
+        ckan, client::Client, csw, doris_bfs, geo_network_q, smart_finder, wasser_de, Config,
+        Source, Type,
     },
     metrics::Metrics,
 };
@@ -99,8 +100,9 @@ async fn harvest(
         Type::Ckan => ckan::harvest(&dir, client, &source).await,
         Type::Csw => csw::harvest(&dir, client, &source).await,
         Type::WasserDe => wasser_de::harvest(&dir, client, &source).await,
-        Type::DorisBfs => doris_bfs::harvest(&dir, client, &source).await,
         Type::GeoNetworkQ => geo_network_q::harvest(&dir, client, &source).await,
+        Type::DorisBfs => doris_bfs::harvest(&dir, client, &source).await,
+        Type::SmartFinder => smart_finder::harvest(&dir, client, &source).await,
     };
 
     let (count, transmitted, failed) =

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod csw;
 pub mod doris_bfs;
 pub mod geo_network_q;
+pub mod smart_finder;
 pub mod wasser_de;
 
 use std::fmt;
@@ -161,4 +162,5 @@ pub enum Type {
     WasserDe,
     GeoNetworkQ,
     DorisBfs,
+    SmartFinder,
 }

--- a/src/harvester/smart_finder.rs
+++ b/src/harvester/smart_finder.rs
@@ -1,0 +1,116 @@
+use std::borrow::Cow;
+
+use anyhow::Result;
+use cap_std::fs::Dir;
+use serde::{Deserialize, Serialize};
+use serde_json::from_str;
+use smallvec::SmallVec;
+
+use crate::{
+    dataset::{Dataset, License},
+    harvester::{client::Client, fetch_many, write_dataset, Source},
+};
+
+pub async fn harvest(dir: &Dir, client: &Client, source: &Source) -> Result<(usize, usize, usize)> {
+    let rows = source.batch_size;
+
+    let (count, results, errors) = fetch_datasets(dir, client, source, rows, 0).await?;
+    tracing::info!("Harvesting {} datasets", count);
+
+    let requests = (count + rows - 1) / rows;
+    let start = (1..requests).map(|request| request * rows);
+
+    let (results, errors) = fetch_many(source, results, errors, start, |start| {
+        fetch_datasets(dir, client, source, rows, start)
+    })
+    .await;
+
+    Ok((count, results, errors))
+}
+
+#[tracing::instrument(skip(dir, client, source))]
+async fn fetch_datasets(
+    dir: &Dir,
+    client: &Client,
+    source: &Source,
+    rows: usize,
+    start: usize,
+) -> Result<(usize, usize, usize)> {
+    tracing::debug!("Fetching {} datasets starting at {}", rows, start);
+
+    let body = client
+        .make_request(&format!("{}-{}", source.name, start), |client| async {
+            client
+                .get(source.url.clone())
+                .query(&SelectParams {
+                    q: "*",
+                    rows,
+                    start,
+                })
+                .send()
+                .await?
+                .error_for_status()?
+                .text()
+                .await
+        })
+        .await?;
+
+    let response = from_str::<SelectResponse>(&body)?;
+
+    let count = response.results.num_found;
+    let results = response.results.docs.len();
+    let mut errors = 0;
+
+    for doc in response.results.docs {
+        if let Err(err) = translate_dataset(dir, source, doc).await {
+            tracing::error!("{:#}", err);
+
+            errors += 1;
+        }
+    }
+
+    Ok((count, results, errors))
+}
+
+async fn translate_dataset(dir: &Dir, source: &Source, doc: Document<'_>) -> Result<()> {
+    let dataset = Dataset {
+        title: doc.title,
+        description: doc.description,
+        license: License::Unknown,
+        tags: Vec::new(),
+        source_url: source.source_url().replace("{{id}}", &doc.id),
+        resources: SmallVec::new(),
+        issued: None,
+    };
+
+    write_dataset(dir, &doc.id, dataset).await
+}
+
+#[derive(Debug, Serialize)]
+struct SelectParams<'a> {
+    q: &'a str,
+    rows: usize,
+    start: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct SelectResponse<'a> {
+    #[serde(rename = "response", borrow)]
+    results: Results<'a>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Results<'a> {
+    #[serde(rename = "numFound")]
+    num_found: usize,
+    #[serde(borrow)]
+    docs: Vec<Document<'a>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Document<'a> {
+    #[serde(borrow)]
+    id: Cow<'a, str>,
+    title: String,
+    description: String,
+}


### PR DESCRIPTION
This can also be used with the SmartFinder-based UBA GDI, but for now our CSW
harvester provides more dataset fields.

Note that the JSON documents also contain the full CSW records as XML text in
their content field.

Closes #65 