### PR TITLE
Use dumps of the GeoNames database to resolve geographic region names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +394,28 @@ checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1958,6 +1992,7 @@ dependencies = [
  "time",
  "uuid",
  "winapi",
+ "zstd",
 ]
 
 [[package]]
@@ -2285,6 +2320,7 @@ dependencies = [
  "bincode",
  "bytes",
  "cap-std",
+ "csv",
  "futures-util",
  "hashbrown",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ axum = { version = "0.5", default-features = false, features = ["http1", "query"
 bincode = "1.3"
 bytes = "1.2"
 cap-std = "0.25"
+csv = "1.1"
 futures-util = { version = "0.3", default-features = false }
 once_cell = { version = "1.13", features = ["parking_lot"] }
 hashbrown = { version = "0.12", features = ["serde"] }
@@ -28,7 +29,7 @@ serde_json = "1.0"
 serde-roxmltree = "0.3"
 smallvec = { version = "1.9", features = ["union", "const_generics", "serde"] }
 string_cache = "0.8"
-tantivy = { version = "0.18", default-features = false, features = ["mmap"] }
+tantivy = { version = "0.18", default-features = false, features = ["mmap", "zstd-compression"] }
 time = { version = "0.3", features = ["formatting", "macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "parking_lot"] }
 toml = "0.5"

--- a/analysis/regions.py
+++ b/analysis/regions.py
@@ -1,0 +1,24 @@
+import collections
+
+from fetch import fetch
+
+count = 0
+other = 0
+
+names = collections.Counter()
+
+for (_source, _id, dataset) in fetch():
+    region = dataset["region"]
+
+    if region:
+        count += 1
+
+        if "Other" in region:
+            other += 1
+
+            names[region["Other"]] += 1
+
+print(f"{count} regions, {other} ({100 * other / count:.1f}) unknown")
+
+for (name, count) in names.most_common():
+    print(f"{name}: {count}")

--- a/src/bin/geonames.rs
+++ b/src/bin/geonames.rs
@@ -1,0 +1,74 @@
+use std::fs::{create_dir, remove_dir_all};
+use std::io::stdin;
+
+use anyhow::Result;
+use csv::ReaderBuilder;
+use serde::Deserialize;
+use tantivy::{
+    schema::{NumericOptions, Schema, STORED, STRING},
+    store::Compressor,
+    Document, Index, IndexSettings,
+};
+
+use umwelt_info::data_path_from_env;
+
+fn main() -> Result<()> {
+    let mut schema = Schema::builder();
+
+    let id = schema.add_u64_field("id", NumericOptions::default().set_indexed().set_stored());
+    let name = schema.add_text_field("name", STRING | STORED);
+    let alt_names = schema.add_text_field("alt_names", STRING);
+
+    let schema = schema.build();
+
+    let data_path = data_path_from_env();
+    let index_path = data_path.join("geonames");
+
+    let _ = remove_dir_all(&index_path);
+    create_dir(&index_path)?;
+
+    let index = Index::builder()
+        .schema(schema)
+        .settings(IndexSettings {
+            docstore_compression: Compressor::Zstd,
+            ..Default::default()
+        })
+        .create_in_dir(index_path)?;
+
+    let mut writer = index.writer(128 << 20)?;
+
+    let mut reader = ReaderBuilder::new()
+        .delimiter(b'\t')
+        .has_headers(false)
+        .from_reader(stdin());
+
+    for record in reader.deserialize::<Record>() {
+        let record = record?;
+
+        let mut doc = Document::default();
+
+        doc.add_u64(id, record.id);
+
+        doc.add_text(name, record.name);
+
+        doc.add_text(alt_names, record.ascii_name);
+
+        for alt_name in record.alt_names.split(',') {
+            doc.add_text(alt_names, alt_name);
+        }
+
+        writer.add_document(doc)?;
+    }
+
+    writer.commit()?;
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct Record {
+    id: u64,
+    name: String,
+    ascii_name: String,
+    alt_names: String,
+}

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -11,6 +11,7 @@ fn main() -> Result<()> {
         Some("harvester") => harvester(),
         Some("indexer") => indexer(),
         Some("server") => server(),
+        Some("geonames") => geonames(),
         Some(name) => Err(anyhow!("Unknown task {}", name)),
     }
 }
@@ -72,6 +73,19 @@ fn server() -> Result<()> {
             ("BIND_ADDR", "127.0.0.1:8081"),
             ("REQUEST_LIMIT", "32"),
             ("RUST_LOG", "info,umwelt_info=debug,server=debug"),
+        ],
+    )?;
+
+    Ok(())
+}
+
+fn geonames() -> Result<()> {
+    cargo(
+        "GeoNames",
+        ["run", "--bin", "geonames", "--release"],
+        [
+            ("DATA_PATH", "data"),
+            ("RUST_LOG", "info,umwelt_info=debug,geonames=debug"),
         ],
     )?;
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -1,5 +1,6 @@
 mod contact;
 mod license;
+mod region;
 mod resource;
 mod tag;
 
@@ -16,6 +17,7 @@ use tokio::{fs::File as AsyncFile, io::AsyncWriteExt};
 
 pub use contact::Contact;
 pub use license::License;
+pub use region::Region;
 pub use resource::{Resource, Type as ResourceType};
 pub use tag::Tag;
 
@@ -28,7 +30,7 @@ pub struct Dataset {
     pub license: License,
     pub contacts: Vec<Contact>,
     pub tags: Vec<Tag>,
-    pub region: Option<String>,
+    pub region: Option<Region>,
     pub issued: Option<Date>,
     pub last_checked: Option<Date>,
     pub source_url: String,

--- a/src/dataset/region.rs
+++ b/src/dataset/region.rs
@@ -1,0 +1,37 @@
+use std::fmt;
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use crate::{data_path_from_env, geonames::GeoNames};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Region {
+    Other(String),
+    GeoName(u64),
+}
+
+impl From<&'_ str> for Region {
+    fn from(val: &str) -> Self {
+        if let Some(id) = GEO_NAMES.r#match(val).unwrap() {
+            Self::GeoName(id)
+        } else {
+            Self::Other(val.to_owned())
+        }
+    }
+}
+
+impl fmt::Display for Region {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Other(val) => fmt.write_str(val),
+            Self::GeoName(id) => {
+                let name = GEO_NAMES.resolve(*id).unwrap();
+
+                fmt.write_str(&name)
+            }
+        }
+    }
+}
+
+static GEO_NAMES: Lazy<GeoNames> = Lazy::new(|| GeoNames::open(&data_path_from_env()).unwrap());

--- a/src/dataset/region.rs
+++ b/src/dataset/region.rs
@@ -1,9 +1,8 @@
 use std::fmt;
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use crate::{data_path_from_env, geonames::GeoNames};
+use crate::geonames::GEO_NAMES;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Region {
@@ -13,11 +12,11 @@ pub enum Region {
 
 impl From<&'_ str> for Region {
     fn from(val: &str) -> Self {
-        if let Some(id) = GEO_NAMES.r#match(val).unwrap() {
-            Self::GeoName(id)
-        } else {
-            Self::Other(val.to_owned())
+        if let Some(id) = GEO_NAMES.r#match(val) {
+            return Self::GeoName(id);
         }
+
+        Self::Other(val.to_owned())
     }
 }
 
@@ -26,12 +25,10 @@ impl fmt::Display for Region {
         match self {
             Self::Other(val) => fmt.write_str(val),
             Self::GeoName(id) => {
-                let name = GEO_NAMES.resolve(*id).unwrap();
+                let name = GEO_NAMES.resolve(*id);
 
                 fmt.write_str(&name)
             }
         }
     }
 }
-
-static GEO_NAMES: Lazy<GeoNames> = Lazy::new(|| GeoNames::open(&data_path_from_env()).unwrap());

--- a/src/dataset/region.rs
+++ b/src/dataset/region.rs
@@ -10,6 +10,17 @@ pub enum Region {
     GeoName(u64),
 }
 
+impl Region {
+    pub fn url(&self) -> Option<String> {
+        let val = match self {
+            Self::Other(_) => return None,
+            Self::GeoName(id) => format!("https://www.geonames.org/{}/", id),
+        };
+
+        Some(val)
+    }
+}
+
 impl From<&'_ str> for Region {
     fn from(val: &str) -> Self {
         if let Some(id) = GEO_NAMES.r#match(val) {

--- a/src/geonames.rs
+++ b/src/geonames.rs
@@ -1,0 +1,78 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use tantivy::{
+    collector::TopDocs,
+    query::{BooleanQuery, TermQuery},
+    schema::{Field, IndexRecordOption},
+    Index, IndexReader, Term,
+};
+
+pub struct GeoNames {
+    reader: IndexReader,
+    id: Field,
+    name: Field,
+    alt_names: Field,
+}
+
+impl GeoNames {
+    pub fn open(data_path: &Path) -> Result<Self> {
+        let index = Index::open_in_dir(data_path.join("geonames"))?;
+
+        let reader = index.reader()?;
+
+        let schema = index.schema();
+
+        let id = schema.get_field("id").unwrap();
+        let name = schema.get_field("name").unwrap();
+        let alt_names = schema.get_field("alt_names").unwrap();
+
+        Ok(Self {
+            reader,
+            id,
+            name,
+            alt_names,
+        })
+    }
+
+    pub fn r#match(&self, name: &str) -> Result<Option<u64>> {
+        let query = BooleanQuery::union(vec![
+            Box::new(TermQuery::new(
+                Term::from_field_text(self.name, name),
+                IndexRecordOption::Basic,
+            )),
+            Box::new(TermQuery::new(
+                Term::from_field_text(self.alt_names, name),
+                IndexRecordOption::Basic,
+            )),
+        ]);
+
+        let searcher = self.reader.searcher();
+        let docs = searcher.search(&query, &TopDocs::with_limit(1))?;
+
+        if let Some((_score, doc)) = docs.into_iter().next() {
+            let doc = searcher.doc(doc)?;
+
+            let id = doc.get_first(self.id).unwrap().as_u64().unwrap();
+
+            Ok(Some(id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn resolve(&self, id: u64) -> Result<String> {
+        let query = TermQuery::new(Term::from_field_u64(self.id, id), IndexRecordOption::Basic);
+
+        let searcher = self.reader.searcher();
+        let docs = searcher.search(&query, &TopDocs::with_limit(1))?;
+
+        let (_score, doc) = docs.into_iter().next().ok_or_else(|| anyhow!(""))?;
+
+        let doc = searcher.doc(doc)?;
+
+        let name = doc.get_first(self.name).unwrap().as_text().unwrap();
+
+        Ok(name.to_owned())
+    }
+}

--- a/src/harvester/wasser_de.rs
+++ b/src/harvester/wasser_de.rs
@@ -118,7 +118,7 @@ async fn translate_dataset(dir: &Dir, source: &Source, document: Document) -> Re
         license: document.license.as_str().into(),
         contacts,
         tags,
-        region: document.region_name,
+        region: document.region_name.as_deref().map(Into::into),
         issued,
         last_checked,
         source_url: source.url.clone().into(),

--- a/src/index.rs
+++ b/src/index.rs
@@ -11,8 +11,9 @@ use tantivy::{
         Facet, FacetOptions, Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions,
         Value, FAST, STORED, STRING,
     },
+    store::Compressor,
     tokenizer::{Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer, TextAnalyzer},
-    Document, Index, IndexReader, IndexWriter, Score, SegmentReader, Term,
+    Document, Index, IndexReader, IndexSettings, IndexWriter, Score, SegmentReader, Term,
 };
 
 use crate::dataset::Dataset;
@@ -176,7 +177,14 @@ impl Indexer {
         let schema = schema();
         let fields = Fields::new(&schema);
 
-        let index = Index::open_or_create(MmapDirectory::open(index_path)?, schema)?;
+        let index = Index::builder()
+            .schema(schema)
+            .settings(IndexSettings {
+                docstore_compression: Compressor::None,
+                ..Default::default()
+            })
+            .open_or_create(MmapDirectory::open(index_path)?)?;
+
         register_tokenizers(&index);
 
         let writer = index.writer(128 << 20)?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -9,7 +9,7 @@ use tantivy::{
     query::{BooleanQuery, QueryParser, TermQuery},
     schema::{
         Facet, FacetOptions, Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions,
-        Value, FAST, STORED, STRING,
+        FAST, STORED, STRING,
     },
     store::Compressor,
     tokenizer::{Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer, TextAnalyzer},
@@ -135,15 +135,19 @@ impl Searcher {
         let iter = docs.into_iter().map(move |(_score, doc)| {
             let doc = searcher.doc(doc)?;
 
-            let source = match doc.get_first(self.fields.source) {
-                Some(Value::Str(source)) => source.clone(),
-                _ => unreachable!(),
-            };
+            let source = doc
+                .get_first(self.fields.source)
+                .unwrap()
+                .as_text()
+                .unwrap()
+                .to_owned();
 
-            let id = match doc.get_first(self.fields.id) {
-                Some(Value::Str(id)) => id.clone(),
-                _ => unreachable!(),
-            };
+            let id = doc
+                .get_first(self.fields.id)
+                .unwrap()
+                .as_text()
+                .unwrap()
+                .to_owned();
 
             Ok((source, id))
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod dataset;
+pub mod geonames;
 pub mod harvester;
 pub mod index;
 pub mod metrics;

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -15,7 +15,11 @@
 
     <h3>Tags: {{ dataset.tags|join(", ") }}</h3>
 
-    {% if let Some(region) = dataset.region %} <p>Region: {{ region }}</p> {% endif %}
+    {% if let Some(region) = dataset.region %}
+
+    <p>Region: {% if let Some(region_url) = region.url() %} <a href="{{ region_url }}">{{ region }}</a> {% else %} {{ region }} {% endif %}</p>
+
+    {% endif %}
 
     <p>License: {% if let Some(license_url) = dataset.license.url() %} <a href="{{ license_url }}">{{ dataset.license }}</a> {% else %} {{ dataset.license }} {% endif %}</p>
 


### PR DESCRIPTION
For now, I am envisioning a manual process of indexing the GeoName database dump via

```console
> cargo xtask geonames < path/to/allCountries.txt
```

and then copying `data/geonames` to the server. In the long run, this is probably a good candidate for a manually triggered but automatically executed CI job.

Closes #78 