### PR TITLE
Add a pseudo-harvester to manually create datasets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,6 @@ assets = [
     ["deployment/harvester.timer", "etc/systemd/system/", "644"],
     ["deployment/indexer.service", "etc/systemd/system/", "644"],
     ["deployment/server.service", "etc/systemd/system/", "644"],
+    ["deployment/harvester.toml", "usr/share/umwelt-info/harvester.toml", "644"],
     ["deployment/manual_datasets.toml", "usr/share/umwelt-info/manual_datasets.toml", "644"],
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,5 @@ assets = [
     ["deployment/harvester.timer", "etc/systemd/system/", "644"],
     ["deployment/indexer.service", "etc/systemd/system/", "644"],
     ["deployment/server.service", "etc/systemd/system/", "644"],
+    ["deployment/manual_datasets.toml", "usr/share/umwelt-info/manual_datasets.toml", "644"],
 ]

--- a/deployment/harvester.service
+++ b/deployment/harvester.service
@@ -7,7 +7,7 @@ RequiresMountsFor=/var/lib/umwelt-info
 [Service]
 User=umwelt-info
 Group=umwelt-info
-Environment=RUST_LOG=info DATA_PATH=/var/lib/umwelt-info
+Environment=RUST_LOG=info DATA_PATH=/var/lib/umwelt-info CONFIG_PATH=/usr/share/umwelt-info/harvester.toml
 
 Type=oneshot
 ExecStart=harvester

--- a/deployment/harvester.toml
+++ b/deployment/harvester.toml
@@ -1,4 +1,9 @@
 [[sources]]
+name = "manual"
+type = "manual"
+url = "file://localhost/usr/share/umwelt-info/manual_datasets.toml"
+
+[[sources]]
 name = "stadt-leipzig"
 type = "ckan"
 url = "https://opendata.leipzig.de/"

--- a/deployment/manual_datasets.toml
+++ b/deployment/manual_datasets.toml
@@ -1,0 +1,1 @@
+datasets = []

--- a/src/bin/harvester.rs
+++ b/src/bin/harvester.rs
@@ -23,14 +23,14 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let data_path = data_path_from_env();
-
-    let dir = Dir::open_ambient_dir(&data_path, ambient_authority())?;
-
-    let config = Config::read(&dir)?;
+    let config = Config::read()?;
 
     let count = config.sources.len();
     tracing::info!("Harvesting {} sources", count);
+
+    let data_path = data_path_from_env();
+
+    let dir = Dir::open_ambient_dir(&data_path, ambient_authority())?;
 
     let metrics = Arc::new(Mutex::new(Metrics::default()));
 

--- a/src/bin/harvester.rs
+++ b/src/bin/harvester.rs
@@ -10,8 +10,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use umwelt_info::{
     data_path_from_env,
     harvester::{
-        ckan, client::Client, csw, doris_bfs, geo_network_q, smart_finder, wasser_de, Config,
-        Source, Type,
+        ckan, client::Client, csw, doris_bfs, geo_network_q, manual, smart_finder, wasser_de,
+        Config, Source, Type,
     },
     metrics::Metrics,
 };
@@ -97,6 +97,7 @@ async fn harvest(
     let start = SystemTime::now();
 
     let res = match source.r#type {
+        Type::Manual => manual::harvest(&dir, &source).await,
         Type::Ckan => ckan::harvest(&dir, client, &source).await,
         Type::Csw => csw::harvest(&dir, client, &source).await,
         Type::WasserDe => wasser_de::harvest(&dir, client, &source).await,

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -39,6 +39,7 @@ fn harvester() -> Result<()> {
         ["run", "--bin", "harvester"],
         [
             ("DATA_PATH", "data"),
+            ("CONFIG_PATH", "deployment/harvester.toml"),
             ("RUST_LOG", "info,umwelt_info=debug,harvester=debug"),
         ],
     )?;

--- a/src/harvester/client.rs
+++ b/src/harvester/client.rs
@@ -32,8 +32,9 @@ impl Client {
 
         if !replay {
             let _ = dir.remove_dir_all("responses");
-            dir.create_dir("responses")?;
         }
+
+        dir.create_dir_all("responses")?;
 
         let dir = Arc::new(dir.open_dir("responses")?);
 

--- a/src/harvester/manual.rs
+++ b/src/harvester/manual.rs
@@ -1,0 +1,46 @@
+use anyhow::{anyhow, Result};
+use cap_std::fs::Dir;
+use serde::Deserialize;
+use tokio::fs::read_to_string;
+use toml::from_str;
+
+use crate::{
+    dataset::Dataset,
+    harvester::{write_dataset, Source},
+};
+
+pub async fn harvest(dir: &Dir, source: &Source) -> Result<(usize, usize, usize)> {
+    let path = source
+        .url
+        .to_file_path()
+        .map_err(|()| anyhow!("{} is not a valid path", source.url))?;
+
+    let contents = from_str::<FileContents>(&read_to_string(path).await?)?;
+
+    let count = contents.datasets.len();
+    let mut errors = 0;
+
+    tracing::info!("Harvesting {} datasets", count);
+
+    for dataset in contents.datasets {
+        if let Err(err) = write_dataset(dir, &dataset.id, dataset.dataset).await {
+            tracing::error!("{:#}", err);
+
+            errors += 1;
+        }
+    }
+
+    Ok((count, count, errors))
+}
+
+#[derive(Deserialize)]
+struct FileContents {
+    datasets: Vec<ManualDataset>,
+}
+
+#[derive(Deserialize)]
+struct ManualDataset {
+    id: String,
+    #[serde(flatten)]
+    dataset: Dataset,
+}

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -7,9 +7,10 @@ pub mod manual;
 pub mod smart_finder;
 pub mod wasser_de;
 
+use std::env::var_os;
 use std::fmt;
+use std::fs::read_to_string;
 use std::future::Future;
-use std::io::Read;
 
 use anyhow::{ensure, Result};
 use cap_std::fs::{Dir, OpenOptions as FsOpenOptions};
@@ -78,12 +79,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn read(dir: &Dir) -> Result<Self> {
-        let mut file = dir.open("harvester.toml")?;
+    pub fn read() -> Result<Self> {
+        let path = var_os("CONFIG_PATH").expect("Environment variable CONFIG_PATH not set");
 
-        let mut buf = String::new();
-        file.read_to_string(&mut buf)?;
-        let val = from_str::<Self>(&buf)?;
+        let val = from_str::<Self>(&read_to_string(path)?)?;
 
         {
             let mut source_names = HashSet::new();

--- a/src/harvester/mod.rs
+++ b/src/harvester/mod.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod csw;
 pub mod doris_bfs;
 pub mod geo_network_q;
+pub mod manual;
 pub mod smart_finder;
 pub mod wasser_de;
 
@@ -157,6 +158,7 @@ impl fmt::Debug for Source {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Type {
+    Manual,
     Ckan,
     Csw,
     WasserDe,


### PR DESCRIPTION
Given a source definition like

```toml
[[sources]]
name = "manual"
type = "manual"
url = "file://localhost/usr/share/umwelt-info/manual_datasets.toml"
```

human-readable dataset descriptions like

```toml
[[datasets]]
id = "undine"
title = "Undine"
description = "Informationsplattform zu hydrologischen Extremereignissen (Hochwasser, Niedrigwasser)"
license = "Unknown"
contacts = []
tags = []
source_url = "https://undine.bafg.de/"

[[datasets.resources]]
type = "Unknown"
url = "https://undine.bafg.de/"
```

placed in `/usr/share/umwelt-info/manual_datasets.toml` is parsed and added to the index in binary form.