### PR TITLE
Extend Wasser-DE Metadata Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /data
 __pycache__
+/.vscode

--- a/src/dataset/resource.rs
+++ b/src/dataset/resource.rs
@@ -23,15 +23,38 @@ pub enum Type {
     Pdf,
     Csv,
     JsonLd,
+    Xml,
+    Image,
+    Archive,
+    PlainText,
+}
+
+impl From<&'_ str> for Type {
+    fn from(val: &str) -> Self {
+        match val {
+            "text/plain" => Self::PlainText,
+            "application/pdf" => Self::Pdf,
+            "application/xml" => Self::Xml,
+            "image/png" => Self::Image,
+            "wms_xml" => Self::Image,
+            "application/zip" => Self::Archive,
+            "" => Self::Unknown,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 impl fmt::Display for Type {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let val = match self {
-            Self::Unknown => "unbekannt",
+            Self::Unknown => "Unknown",
             Self::Pdf => "PDF",
             Self::Csv => "CSV",
             Self::JsonLd => "JSON-LD",
+            Self::Xml => "XML",
+            Self::Image => "Image",
+            Self::Archive => "Compressed archive",
+            Self::PlainText => "Plain text",
         };
 
         fmt.write_str(val)

--- a/src/harvester/wasser_de.rs
+++ b/src/harvester/wasser_de.rs
@@ -19,6 +19,8 @@
 //! | REGION_ID                 |                    |                                                              |
 //! | ANSPRECHPARTNER_NAME      | contact_names      |                                                              |
 //! | ANSPRECHPARTNER_EMAIL     | contact_emails     |                                                              |
+//! | AP_NAME                   | contact_names      |                                                              |
+//! | AP_EMAIL                  | contact_emails     |                                                              |
 //! | ANSPRECHPARTNER_NAME_RL1  | contact_names      |                                                              |
 //! | ANSPRECHPARTNER_EMAIL_RL1 | contact_emails     |                                                              |
 //! | ANSPRECHPARTNER_NAME_RL2  | contact_names      |                                                              |
@@ -105,6 +107,7 @@ async fn translate_dataset(dir: &Dir, source: &Source, document: Document) -> Re
     };
 
     push_contact(document.contact_name, document.contact_email);
+    push_contact(document.contact_name_ap, document.contact_email_ap);
     push_contact(document.contact_name_rl1, document.contact_email_rl1);
     push_contact(document.contact_name_rl2, document.contact_email_rl2);
     push_contact(document.contact_name_rl3, document.contact_email_rl3);
@@ -171,6 +174,10 @@ struct Document {
     contact_name: Option<String>,
     #[serde(rename = "ANSPRECHPARTNER_EMAIL")]
     contact_email: Option<String>,
+    #[serde(rename = "AP_NAME")]
+    contact_name_ap: Option<String>,
+    #[serde(rename = "AP_EMAIL")]
+    contact_email_ap: Option<String>,
     #[serde(rename = "ANSPRECHPARTNER_NAME_RL1")]
     contact_name_rl1: Option<String>,
     #[serde(rename = "ANSPRECHPARTNER_EMAIL_RL1")]

--- a/src/harvester/wasser_de.rs
+++ b/src/harvester/wasser_de.rs
@@ -12,6 +12,7 @@
 //! | LICENSE_NAME_LANG         |                    |                                                              |
 //! | RICHTLINIE_IDS            | tags               |                                                              |
 //! | URL                       | resource           |                                                              |
+//! | CONTENTTYPE               | resource.type      | Mime-type of the linked ressource, reduced to category       |
 //! | JAHR_VEROEFFENTLICHUNG    | issued             | http://purl.org/dc/terms/issued                              |
 //! | KOMMENTAR                 | comment            |                                                              |
 //! | LAST_CHECKED              | last_checked       | Last time the Wasser-DE staff checked this document          |
@@ -125,7 +126,10 @@ async fn translate_dataset(dir: &Dir, source: &Source, document: Document) -> Re
         issued,
         last_checked,
         source_url: source.url.clone().into(),
-        resources: smallvec![Resource::unknown(document.url)],
+        resources: smallvec![Resource {
+            r#type: document.content_type.as_str().into(),
+            url: document.url
+        }],
     };
 
     write_dataset(dir, &document.id.to_string(), dataset).await
@@ -194,6 +198,8 @@ struct Document {
     contact_name_rl4: Option<String>,
     #[serde(rename = "ANSPRECHPARTNER_EMAIL_RL4")]
     contact_email_rl4: Option<String>,
+    #[serde(rename = "CONTENTTYPE")]
+    content_type: String,
 }
 
 impl Document {


### PR DESCRIPTION
Further extend the metadata scheme used aiming for full coverage of all entries listed by Wasser-DE
